### PR TITLE
Travis CI for build pass validation and continuous integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+# environment settings.
+dist: bionic
+os: linux
+language: c
+compiler: gcc
+
+# variables.
+env:
+  - PARSEC_VERSION=5.0
+
+# dependencies.
+install:
+  - sudo apt-get install libgl-dev libsdl2-dev libsdl2-ttf-dev libusb-1.0-0-dev libusbredirhost-dev libusbredirparser-dev libx11-dev sudo tar wget
+
+# preparation.
+before_script:
+  - sh autogen.sh
+
+# compilation.
+script:
+  - set -o errexit; source .travis/01-shared-linking.sh
+  - set -o errexit; source .travis/02-dso-linking.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
+# Copyright (c) 2021 Maik Broemme <mbroemme@libmpq.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # environment settings.
 dist: bionic
 os: linux

--- a/.travis/01-shared-linking.sh
+++ b/.travis/01-shared-linking.sh
@@ -1,0 +1,38 @@
+#!/bin/env bash
+#
+# 01-shared-linking.sh -- shared linking against parsec sdk.
+#
+# Copyright (c) 2021 Maik Broemme <mbroemme@libmpq.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# parsec sdk download.
+wget "https://github.com/parsec-cloud/parsec-sdk/archive/${PARSEC_VERSION}.tar.gz"
+tar xzf "${PARSEC_VERSION}.tar.gz"
+
+# parsec sdk installation.
+sudo install -D -m 0755 "parsec-sdk-${PARSEC_VERSION}/sdk/linux/libparsec.so" "/usr/lib/parsec/sdk/linux/libparsec.so"
+sudo install -D -m 0644 "parsec-sdk-${PARSEC_VERSION}/sdk/parsec.h" "/usr/include/parsec/sdk/parsec.h"
+
+# parsec sdk link shared libraries.
+sudo ln -s "parsec/sdk/linux/libparsec.so" "/usr/lib/libparsec.so"
+sudo ln -s "parsec/sdk/linux/libparsec.so" "/usr/lib/libparsec.so.${PARSEC_VERSION}"
+
+# parsec sdk link include files.
+sudo ln -s "sdk/parsec.h" "/usr/include/parsec/parsec.h"
+
+# compilation.
+./configure --prefix=/usr
+make
+make distclean

--- a/.travis/02-dso-linking.sh
+++ b/.travis/02-dso-linking.sh
@@ -1,0 +1,30 @@
+#!/bin/env bash
+#
+# 01-shared-linking.sh -- shared linking against parsec sdk.
+#
+# Copyright (c) 2021 Maik Broemme <mbroemme@libmpq.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# parsec sdk download.
+wget "https://github.com/parsec-cloud/parsec-sdk/archive/${PARSEC_VERSION}.tar.gz"
+tar xzf "${PARSEC_VERSION}.tar.gz"
+
+# parsec sdk installation.
+mv "parsec-sdk-${PARSEC_VERSION}" "parsec-sdk"
+
+# compilation.
+./configure --prefix=/usr
+make
+make distclean


### PR DESCRIPTION
This PR adds basic support for continuous integration testing using Travis CI. Currently only two scenarios are tested:

1. Shared linking against Parsec libraries installed into system-wide library and include paths.
2. DSO linking of Parsec library installed in source root under `parsec-sdk` directory.

Later we can simply extend it to do build validation testing for Windows and macOS cross compilation.