### PR TITLE
Fixes for 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,7 @@ without chroma subsampling for sharp and crystal clear text.
 * Fully CLI based customization. User can specify all required parameters via
   command line switches, allow perfect integration into different window
   managers.
-* Desktop in window support with [XGrabKeyboard](https://tronche.com/gui/x/xlib/input/XGrabKeyboard.html)
-  and [XUngrabKeyboard](https://tronche.com/gui/x/xlib/input/XUngrabKeyboard.html)
+* Desktop in window support with [SDL_SetWindowKeyboardGrab](https://wiki.libsdl.org/SDL_SetWindowKeyboardGrab)
   while leaving mouse pointer ungrabbed. Supporting Alt+Tab and Windows special
   keys grab, even if assigned to the window manager.
 * SDL window is created without `SDL_WINDOW_RESIZABLE` flag set, so window
@@ -160,14 +159,14 @@ without chroma subsampling for sharp and crystal clear text.
 # Building
 
 VDI Stream Client uses GNU Build System to configure, build and install the
-application. It requires `sdl2`, `sdl2_ttf`, `libx11`, `libglvnd`, `libusb`,
-`usbredir` and the [Parsec SDK](https://github.com/parsec-cloud/parsec-sdk).
-The build system will search the SDK first in build directory and use DSO
-linking, the resulting binary will be redistributable but you need to ship
-Parsec library somehow. If not found, it will search in system-wide include and
-library directories and link accordingly, binary may not be redistributable.
-For build and install use the commands below and if `--prefix=/usr` is used,
-the `make install` command must be run as root user.
+application. It requires `sdl2`, `sdl2_ttf`, `libglvnd`, `libusb`, `usbredir`
+and the [Parsec SDK](https://github.com/parsec-cloud/parsec-sdk). The build
+system will search the SDK first in build directory and use DSO linking, the
+resulting binary will be redistributable but you need to ship Parsec library
+somehow. If not found, it will search in system-wide include and library
+directories and link accordingly, binary may not be redistributable. For build
+and install use the commands below and if `--prefix=/usr` is used, the
+`make install` command must be run as root user.
 
 ```
 git clone https://github.com/parsec-cloud/parsec-sdk

--- a/configure.ac
+++ b/configure.ac
@@ -21,14 +21,11 @@ PKG_PROG_PKG_CONFIG
 AC_CHECK_HEADER([dlfcn.h], [], [AC_MSG_ERROR([*** dlfcn.h is required, install glibc header files])])
 AC_CHECK_LIB([dl], [dlopen], [], [AC_MSG_ERROR([*** dlopen is required, install glibc library files])])
 
-# checking for libx11 library.
-PKG_CHECK_MODULES([X11], [x11])
-
 # checking for libglvnd library.
 PKG_CHECK_MODULES([GL], [gl])
 
 # checking for sdl2 library.
-PKG_CHECK_MODULES([SDL2], [sdl2 >= 2.0.5])
+PKG_CHECK_MODULES([SDL2], [sdl2 >= 2.0.16])
 
 # checking for sdl2_ttf library.
 PKG_CHECK_MODULES([SDL2_TTF], [SDL2_ttf >= 2.0.5])

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -73,7 +73,9 @@ static void vdi_stream_client__cursor(struct parsec_context_s *parsec_context, P
 		}
 	}
 
-	if (cursor->relative == SDL_TRUE && cursor->hidden == SDL_TRUE) {
+	if (SDL_GetRelativeMouseMode() == SDL_FALSE &&
+	    cursor->relative == SDL_TRUE &&
+	    cursor->hidden == SDL_TRUE) {
 		SDL_ShowCursor(SDL_FALSE);
 		SDL_SetRelativeMouseMode(SDL_TRUE);
 		if (parsec_context->pressed == SDL_FALSE && grab_forced == SDL_FALSE) {
@@ -81,7 +83,9 @@ static void vdi_stream_client__cursor(struct parsec_context_s *parsec_context, P
 		}
 		parsec_context->relative = cursor->relative;
 	}
-	if (cursor->relative == SDL_FALSE && cursor->hidden == SDL_FALSE) {
+	if (SDL_GetRelativeMouseMode() == SDL_TRUE &&
+	    cursor->relative == SDL_FALSE &&
+	    cursor->hidden == SDL_FALSE) {
 		SDL_SetRelativeMouseMode(SDL_FALSE);
 		SDL_ShowCursor(SDL_TRUE);
 		SDL_WarpMouseInWindow(parsec_context->window, cursor->positionX, cursor->positionY);

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -74,22 +74,18 @@ static void vdi_stream_client__cursor(struct parsec_context_s *parsec_context, P
 	}
 
 	if (SDL_GetRelativeMouseMode() == SDL_FALSE &&
-	    cursor->relative == SDL_TRUE &&
-	    cursor->hidden == SDL_TRUE) {
+	   (cursor->relative == SDL_TRUE || cursor->hidden == SDL_TRUE)) {
 		SDL_ShowCursor(SDL_FALSE);
 		SDL_SetRelativeMouseMode(SDL_TRUE);
 		if (parsec_context->pressed == SDL_FALSE && grab_forced == SDL_FALSE) {
 			SDL_SetWindowTitle(parsec_context->window, "VDI Stream Client (Press Ctrl+Alt to release grab)");
 		}
 		parsec_context->relative = cursor->relative;
-	}
-	if (SDL_GetRelativeMouseMode() == SDL_TRUE &&
-	    cursor->relative == SDL_FALSE &&
-	    cursor->hidden == SDL_FALSE) {
+	} else if (SDL_GetRelativeMouseMode() == SDL_TRUE &&
+	   (cursor->relative == SDL_FALSE || cursor->hidden == SDL_FALSE)) {
 		SDL_SetRelativeMouseMode(SDL_FALSE);
 		SDL_ShowCursor(SDL_TRUE);
-		SDL_WarpMouseInWindow(parsec_context->window, cursor->positionX, cursor->positionY);
-		if (parsec_context->pressed == SDL_FALSE && grab == SDL_FALSE && grab_forced == SDL_FALSE) {
+		if (parsec_context->pressed == SDL_FALSE && grab_forced == SDL_FALSE && grab == SDL_FALSE) {
 			SDL_SetWindowTitle(parsec_context->window, "VDI Stream Client");
 		}
 		parsec_context->relative = cursor->relative;


### PR DESCRIPTION
Quick fixes before port to SDL3:

1. Support for `SDL_SetWindowKeyboardGrab()`, no more direct `libx11` dependency.
2. Grab cursor only if necessary.
3. Don't generate mouse motion event when leaving relative mode