### PR TITLE
Prepare v0.3.1 stability fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,6 +119,8 @@ jobs:
 
           printf '%s\n' "${GPG_PRIVATE_KEY}" | gpg --batch --import
           gpg --batch --list-secret-keys --keyid-format LONG
+          key_fingerprint="$(gpg --batch --with-colons --list-secret-keys | awk -F: '/^fpr:/ { print $10; exit }')"
+          gpg --batch --armor --export "${key_fingerprint}" > dist/vdi-stream-client-release-signing-key.asc
           gpg --batch --yes --pinentry-mode loopback \
             --passphrase "${GPG_PASSPHRASE}" \
             --detach-sig --armor dist/SHA256SUMS
@@ -150,6 +152,7 @@ jobs:
               "dist/vdi-stream-client-${version}.tar.bz2" \
               dist/SHA256SUMS \
               dist/SHA256SUMS.asc \
+              dist/vdi-stream-client-release-signing-key.asc \
               --clobber
           else
             gh release create "${tag}" \
@@ -157,6 +160,7 @@ jobs:
               "dist/vdi-stream-client-${version}.tar.bz2" \
               dist/SHA256SUMS \
               dist/SHA256SUMS.asc \
+              dist/vdi-stream-client-release-signing-key.asc \
               --verify-tag \
               --title "${tag}" \
               --notes-from-tag

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # the autoconf initilization.
-AC_INIT(vdi-stream-client, 0.3.0, [mbroemme@libmpq.org], [vdi-stream-client])
+AC_INIT(vdi-stream-client, 0.3.1, [mbroemme@libmpq.org], [vdi-stream-client])
 
 # detect the canonical target environment.
 AC_CANONICAL_TARGET

--- a/src/audio.c
+++ b/src/audio.c
@@ -82,9 +82,14 @@ vdi_stream_client__audio_thread(void *opaque)
 
         /* poll audio only if connected. */
         if (vdi_stream_client__context_connected(parsec_context)) {
-            ParsecClientPollAudio(
-                parsec_context->parsec, vdi_stream_client__audio, 100, parsec_context
-            );
+            vdi_stream_client__context_set_audio_polling(parsec_context, true);
+            if (vdi_stream_client__context_connected(parsec_context) &&
+                !vdi_stream_client__context_done(parsec_context)) {
+                ParsecClientPollAudio(
+                    parsec_context->parsec, vdi_stream_client__audio, 100, parsec_context
+                );
+            }
+            vdi_stream_client__context_set_audio_polling(parsec_context, false);
         }
 
         /* delay loop if in reconnect state. */

--- a/src/audio.c
+++ b/src/audio.c
@@ -54,13 +54,15 @@ vdi_stream_client__audio(const Sint16 *pcm, Uint32 frames, void *opaque)
     queued_frames = (Uint32)size / (PARSEC_AUDIO_CHANNELS * sizeof(Sint16));
     queued_packets = queued_frames / PARSEC_AUDIO_FRAMES_PER_PACKET;
 
-    if (parsec_context->playing && queued_packets > parsec_context->max_buffer) {
+    if (vdi_stream_client__context_playing(parsec_context) &&
+        queued_packets > parsec_context->max_buffer) {
         SDL_ClearAudioStream(parsec_context->audio);
         SDL_PauseAudioStreamDevice(parsec_context->audio);
-        parsec_context->playing = false;
-    } else if (!parsec_context->playing && queued_packets >= parsec_context->min_buffer) {
+        vdi_stream_client__context_set_playing(parsec_context, false);
+    } else if (!vdi_stream_client__context_playing(parsec_context) &&
+               queued_packets >= parsec_context->min_buffer) {
         SDL_ResumeAudioStreamDevice(parsec_context->audio);
-        parsec_context->playing = true;
+        vdi_stream_client__context_set_playing(parsec_context, true);
     }
 
     if (!SDL_PutAudioStreamData(
@@ -76,23 +78,23 @@ vdi_stream_client__audio_thread(void *opaque)
 {
     struct parsec_context_s *parsec_context = (struct parsec_context_s *)opaque;
 
-    while (!parsec_context->done) {
+    while (!vdi_stream_client__context_done(parsec_context)) {
 
         /* poll audio only if connected. */
-        if (parsec_context->connection) {
+        if (vdi_stream_client__context_connected(parsec_context)) {
             ParsecClientPollAudio(
                 parsec_context->parsec, vdi_stream_client__audio, 100, parsec_context
             );
         }
 
         /* delay loop if in reconnect state. */
-        if (!parsec_context->connection) {
+        if (!vdi_stream_client__context_connected(parsec_context)) {
 
             /* clear queue and pause audio device. */
-            if (parsec_context->playing) {
+            if (vdi_stream_client__context_playing(parsec_context)) {
                 SDL_ClearAudioStream(parsec_context->audio);
                 SDL_PauseAudioStreamDevice(parsec_context->audio);
-                parsec_context->playing = false;
+                vdi_stream_client__context_set_playing(parsec_context, false);
             }
             SDL_Delay(parsec_context->timeout);
         }

--- a/src/client.c
+++ b/src/client.c
@@ -33,7 +33,9 @@
 #include "parsec.h"
 
 /* system includes. */
+#include <errno.h>
 #include <getopt.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -277,8 +279,10 @@ main(int argc, char **argv)
             }
             continue;
         case OPTION_TIMEOUT:
-            timeout = strtol(optarg, &endptr, 10);
-            if (*endptr != '\0' || timeout <= 0) {
+            errno = 0;
+            timeout = strtoll(optarg, &endptr, 10);
+            if (endptr == optarg || *endptr != '\0' || errno == ERANGE || timeout <= 0 ||
+                timeout > UINT32_MAX / 1000) {
                 SDL_LogError(
                     SDL_LOG_CATEGORY_APPLICATION, "%s: invalid timeout: %s\n", program_name, optarg
                 );

--- a/src/client.c
+++ b/src/client.c
@@ -124,13 +124,13 @@ main(int argc, char **argv)
     static const vdi_server_addr_u zero_server_addr = { 0 };
 
     /* temp variables for command line parser. */
-    Sint32 device;
+    Uint32 device;
     Sint32 type;
     char *redirect;
     char *item;
     char *delim;
     char *endptr;
-    Uint64 port;
+    Sint64 port;
     Sint64 timeout;
     Sint64 speed;
     Sint64 width;
@@ -392,7 +392,7 @@ main(int argc, char **argv)
         case OPTION_REDIRECT:
 
             /* loop through multiple redirect configs. */
-            device = 0;
+            device = vdi_config->usb_count;
             while ((redirect = strsep(&argv[optind - 1], ",")) != NULL) {
 
                 /* check if number of usb redirects are out of range. */
@@ -527,10 +527,10 @@ main(int argc, char **argv)
                         }
 
                         /* convert port string to integer. */
-                        port = strtol(item, NULL, 10);
+                        port = strtol(item, &endptr, 10);
 
                         /* check if port is out of range. */
-                        if (port <= 0 || port >= 65536) {
+                        if (endptr == item || *endptr != '\0' || port <= 0 || port >= 65536) {
                             SDL_LogError(
                                 SDL_LOG_CATEGORY_APPLICATION,
                                 "%s: invalid port in usb redirection: %s\n", program_name, item
@@ -543,12 +543,12 @@ main(int argc, char **argv)
                         }
 
                         /* check if ipv4 address has been assigned previosuly. */
-                        if (vdi_config->server_addrs[device].v4.sin_family != AF_INET) {
+                        if (vdi_config->server_addrs[device].v4.sin_family == AF_INET) {
                             vdi_config->server_addrs[device].v4.sin_port = htons(port);
                         }
 
                         /* check if ipv6 address has been assigned previosuly. */
-                        if (vdi_config->server_addrs[device].v6.sin6_family != AF_INET6) {
+                        if (vdi_config->server_addrs[device].v6.sin6_family == AF_INET6) {
                             vdi_config->server_addrs[device].v6.sin6_port = htons(port);
                         }
                     }
@@ -581,6 +581,7 @@ main(int argc, char **argv)
                     goto error;
                 }
                 device++;
+                vdi_config->usb_count = device;
             }
             continue;
 

--- a/src/client.c
+++ b/src/client.c
@@ -415,6 +415,19 @@ main(int argc, char **argv)
                 type = 0;
                 while ((item = strsep(&redirect, "@#")) != NULL) {
 
+                    /* reject additional fields after port. */
+                    if (type > 2) {
+                        SDL_LogError(
+                            SDL_LOG_CATEGORY_APPLICATION,
+                            "%s: invalid usb redirection format: too many fields\n", program_name
+                        );
+                        SDL_LogError(
+                            SDL_LOG_CATEGORY_APPLICATION, "Try `%s --help' for more information.\n",
+                            program_name
+                        );
+                        goto error;
+                    }
+
                     /* usb device. */
                     if (type == 0) {
 
@@ -580,6 +593,20 @@ main(int argc, char **argv)
                     );
                     goto error;
                 }
+
+                /* exactly usb device, ip address and port must be given. */
+                if (type != 3) {
+                    SDL_LogError(
+                        SDL_LOG_CATEGORY_APPLICATION, "%s: invalid usb redirection format\n",
+                        program_name
+                    );
+                    SDL_LogError(
+                        SDL_LOG_CATEGORY_APPLICATION, "Try `%s --help' for more information.\n",
+                        program_name
+                    );
+                    goto error;
+                }
+
                 device++;
                 vdi_config->usb_count = device;
             }

--- a/src/client.c
+++ b/src/client.c
@@ -126,6 +126,7 @@ main(int argc, char **argv)
     /* temp variables for command line parser. */
     Uint32 device;
     Sint32 type;
+    char *redirect_list;
     char *redirect;
     char *item;
     char *delim;
@@ -263,14 +264,14 @@ main(int argc, char **argv)
         /* parsec options. */
         case OPTION_SESSION:
             free(vdi_config->session);
-            vdi_config->session = strdup(argv[optind - 1]);
+            vdi_config->session = strdup(optarg);
             if (vdi_config->session == NULL) {
                 goto error;
             }
             continue;
         case OPTION_PEER:
             free(vdi_config->peer);
-            vdi_config->peer = strdup(argv[optind - 1]);
+            vdi_config->peer = strdup(optarg);
             if (vdi_config->peer == NULL) {
                 goto error;
             }
@@ -393,7 +394,8 @@ main(int argc, char **argv)
 
             /* loop through multiple redirect configs. */
             device = vdi_config->usb_count;
-            while ((redirect = strsep(&argv[optind - 1], ",")) != NULL) {
+            redirect_list = optarg;
+            while ((redirect = strsep(&redirect_list, ",")) != NULL) {
 
                 /* check if number of usb redirects are out of range. */
                 if (device >= USB_MAX) {

--- a/src/client.h
+++ b/src/client.h
@@ -93,6 +93,7 @@ typedef struct vdi_config_s
     Uint64 stats_period;
 
     /* usb options. */
+    Uint32 usb_count; /* number of configured usb redirects. */
     vdi_server_addr_u server_addrs[USB_MAX];
     struct
     {

--- a/src/client.h
+++ b/src/client.h
@@ -49,7 +49,7 @@ typedef struct vdi_config_s
     /* parsec options. */
     char *session;  /* session id for connection. */
     char *peer;     /* peer id for connection. */
-    Uint16 timeout; /* connection timeout in milliseconds. */
+    Uint32 timeout; /* connection timeout in milliseconds. */
     Uint16 speed;   /* mouse wheel sensitivity. (0 - 255) */
     Uint16 width;   /* screen width in pixel. (host resolution is used if not specified) */
     Uint16 height;  /* screen height in pixel. (host resolution is used if not specified) */

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -533,11 +533,11 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     }
 
     /* configure usb. */
-    if (vdi_config->usb_devices[0].vendor != 0) {
+    if (vdi_config->usb_count > 0) {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Initialize USB\n");
 
         /* one thread per one usb device redirect. */
-        for (device = 0; vdi_config->usb_devices[device].vendor != 0; device++) {
+        for (device = 0; device < vdi_config->usb_count; device++) {
 
             /* store main thread context in a pointer. */
             redirect_context[device].parsec_context = &parsec_context;
@@ -953,9 +953,9 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     SDL_SetWindowKeyboardGrab(parsec_context.window, false);
 
     /* stop network threads for usb redirection. */
-    if (vdi_config->usb_devices[0].vendor != 0) {
+    if (vdi_config->usb_count > 0) {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Stop Network Thread\n");
-        for (count = 0; count < USB_MAX; count++) {
+        for (count = 0; count < vdi_config->usb_count; count++) {
             if (network_thread[count] == NULL) {
                 continue;
             }

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -554,7 +554,7 @@ vdi_stream_client__show_connection_overlay(
     *force_redraw = true;
 }
 
-static ParsecStatus
+static void
 vdi_stream_client__handle_connection_status(
     struct parsec_context_s *parsec_context, struct vdi_config_s *vdi_config,
     ParsecClientConfig *cfg, Uint64 *last_time, bool *force_redraw
@@ -590,8 +590,6 @@ vdi_stream_client__handle_connection_status(
         e == PARSEC_OK && !vdi_stream_client__context_connected(parsec_context)) {
         vdi_stream_client__context_set_connection(parsec_context, true);
     }
-
-    return e;
 }
 
 /* parsec event loop. */
@@ -939,7 +937,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
          * redundant presents of the last video frame. */
         parsec_context.render_timeout = local_interaction ? 0 : 5;
 
-        e = vdi_stream_client__handle_connection_status(
+        vdi_stream_client__handle_connection_status(
             &parsec_context, vdi_config, &cfg, &last_time, &force_redraw
         );
 

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -62,6 +62,21 @@ vdi_stream_client__parsec_init(struct parsec_context_s *parsec_context, ParsecCo
 }
 #endif
 
+static ParsecStatus
+vdi_stream_client__parsec_reconnect(
+    struct parsec_context_s *parsec_context, ParsecClientConfig *cfg, struct vdi_config_s *vdi_config
+)
+{
+    ParsecStatus e;
+
+    ParsecClientDisconnect(parsec_context->parsec);
+    e = ParsecClientConnect(parsec_context->parsec, cfg, vdi_config->session, vdi_config->peer);
+    if (e != PARSEC_OK) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Reconnect failed with code: %d\n", e);
+    }
+    return e;
+}
+
 /* parsec clipboard event. */
 static void
 vdi_stream_client__clipboard(struct parsec_context_s *parsec_context, Uint32 id, Uint32 buffer_key)
@@ -895,8 +910,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
             /* render reconnect text. */
             vdi_stream_client__render_text(&parsec_context, "Reconnecting...");
             force_redraw = true;
-            ParsecClientDisconnect(parsec_context.parsec);
-            ParsecClientConnect(parsec_context.parsec, &cfg, vdi_config->session, vdi_config->peer);
+            e = vdi_stream_client__parsec_reconnect(&parsec_context, &cfg, vdi_config);
             vdi_stream_client__context_set_connection(&parsec_context, false);
             last_time = SDL_GetTicks();
         }
@@ -916,8 +930,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
             /* render reconnect text. */
             vdi_stream_client__render_text(&parsec_context, "Reconnecting...");
             force_redraw = true;
-            ParsecClientDisconnect(parsec_context.parsec);
-            ParsecClientConnect(parsec_context.parsec, &cfg, vdi_config->session, vdi_config->peer);
+            e = vdi_stream_client__parsec_reconnect(&parsec_context, &cfg, vdi_config);
             vdi_stream_client__context_set_connection(&parsec_context, false);
             last_time = SDL_GetTicks();
         }

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -604,7 +604,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
                 }
 
                 /* check if we need to toggle runtime configuration. */
-                if ((msg.key.mod & SDL_KMOD_LSHIFT) != 0) {
+                if (vdi_config->grab == 0 && (msg.key.mod & SDL_KMOD_LSHIFT) != 0) {
 
                     /* check if we need to toggle forced grab. */
                     if (msg.key.key == SDLK_F12) {

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -571,7 +571,8 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
             case SDL_EVENT_KEY_DOWN:
 
                 /* check if we need to switch window grab state. */
-                if ((msg.key.mod & SDL_KMOD_LCTRL) != 0 && (msg.key.mod & SDL_KMOD_LALT) != 0) {
+                if (vdi_config->grab == 1 && (msg.key.mod & SDL_KMOD_LCTRL) != 0 &&
+                    (msg.key.mod & SDL_KMOD_LALT) != 0) {
 
                     /* check if no forced grab. */
                     if (!grab_forced) {

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -71,6 +71,8 @@ vdi_stream_client__parsec_reconnect(
     ParsecStatus e;
 
     vdi_stream_client__context_set_connection(parsec_context, false);
+    parsec_context->requested_width = 0;
+    parsec_context->requested_height = 0;
     while (vdi_stream_client__context_audio_polling(parsec_context)) {
         SDL_Delay(1);
     }
@@ -519,7 +521,7 @@ vdi_stream_client__handle_sdl_event(
         pmsg.mouseWheel.y = msg->wheel.y * vdi_config->speed;
         break;
     case SDL_EVENT_CLIPBOARD_UPDATE:
-        if (vdi_config->clipboard == 1) {
+        if (vdi_config->clipboard == 1 && vdi_stream_client__context_connected(parsec_context)) {
             char *clipboard = SDL_GetClipboardText();
 
             if (clipboard != NULL) {
@@ -540,7 +542,7 @@ vdi_stream_client__handle_sdl_event(
         break;
     }
 
-    if (pmsg.type != 0) {
+    if (pmsg.type != 0 && vdi_stream_client__context_connected(parsec_context)) {
         ParsecClientSendMessage(parsec_context->parsec, &pmsg);
     }
 }

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -64,10 +64,16 @@ vdi_stream_client__parsec_init(struct parsec_context_s *parsec_context, ParsecCo
 
 static ParsecStatus
 vdi_stream_client__parsec_reconnect(
-    struct parsec_context_s *parsec_context, ParsecClientConfig *cfg, struct vdi_config_s *vdi_config
+    struct parsec_context_s *parsec_context, ParsecClientConfig *cfg,
+    struct vdi_config_s *vdi_config
 )
 {
     ParsecStatus e;
+
+    vdi_stream_client__context_set_connection(parsec_context, false);
+    while (vdi_stream_client__context_audio_polling(parsec_context)) {
+        SDL_Delay(1);
+    }
 
     ParsecClientDisconnect(parsec_context->parsec);
     e = ParsecClientConnect(parsec_context->parsec, cfg, vdi_config->session, vdi_config->peer);
@@ -911,7 +917,6 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
             vdi_stream_client__render_text(&parsec_context, "Reconnecting...");
             force_redraw = true;
             e = vdi_stream_client__parsec_reconnect(&parsec_context, &cfg, vdi_config);
-            vdi_stream_client__context_set_connection(&parsec_context, false);
             last_time = SDL_GetTicks();
         }
 
@@ -931,7 +936,6 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
             vdi_stream_client__render_text(&parsec_context, "Reconnecting...");
             force_redraw = true;
             e = vdi_stream_client__parsec_reconnect(&parsec_context, &cfg, vdi_config);
-            vdi_stream_client__context_set_connection(&parsec_context, false);
             last_time = SDL_GetTicks();
         }
 

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -41,6 +41,27 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#ifdef HAVE_LIBPARSEC
+static ParsecStatus
+vdi_stream_client__parsec_init(struct parsec_context_s *parsec_context, ParsecConfig *network_cfg)
+{
+    return ParsecInit(PARSEC_VER, network_cfg, NULL, &parsec_context->parsec);
+}
+#else
+static ParsecStatus
+vdi_stream_client__parsec_init(struct parsec_context_s *parsec_context, ParsecConfig *network_cfg)
+{
+    ParsecStatus e = ParsecInit(network_cfg, NULL, "libparsec.so", &parsec_context->parsec);
+
+    /* The vendored DSO wrapper can return PARSEC_OK even if the loaded SDK
+     * initialization failed. Treat a missing inner context as init failure. */
+    if (e == PARSEC_OK && (parsec_context->parsec == NULL || parsec_context->parsec->ps == NULL)) {
+        e = ERR_DEFAULT;
+    }
+    return e;
+}
+#endif
+
 /* parsec clipboard event. */
 static void
 vdi_stream_client__clipboard(struct parsec_context_s *parsec_context, Uint32 id, Uint32 buffer_key)
@@ -345,11 +366,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
 
     /* parsec init. */
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Initialize Parsec\n");
-#ifdef HAVE_LIBPARSEC
-    e = ParsecInit(PARSEC_VER, &network_cfg, NULL, &parsec_context.parsec);
-#else
-    e = ParsecInit(NULL, &network_cfg, "libparsec.so", &parsec_context.parsec);
-#endif
+    e = vdi_stream_client__parsec_init(&parsec_context, &network_cfg);
     if (e != PARSEC_OK) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Initialization failed with code: %d\n", e);
         goto error;

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -108,6 +108,26 @@ vdi_stream_client__render_stats(struct parsec_context_s *parsec_context)
     parsec_context->stats_idle_wait_ms = 0;
 }
 
+/* keep cursor-induced grabs separate from user-requested grabs. */
+static void
+vdi_stream_client__cursor_set_grab(
+    struct parsec_context_s *parsec_context, bool enable, bool grab, bool grab_forced
+)
+{
+    if (enable) {
+        if (!SDL_GetWindowMouseGrab(parsec_context->window)) {
+            SDL_SetWindowMouseGrab(parsec_context->window, true);
+            parsec_context->cursor_grab = true;
+        }
+        return;
+    }
+
+    if (parsec_context->cursor_grab && !grab && !grab_forced) {
+        SDL_SetWindowMouseGrab(parsec_context->window, false);
+    }
+    parsec_context->cursor_grab = false;
+}
+
 /* parsec cursor event. */
 static void
 vdi_stream_client__cursor(
@@ -115,6 +135,14 @@ vdi_stream_client__cursor(
     bool grab_forced
 )
 {
+    bool need_cursor_grab = cursor->relative || (cursor->hidden && parsec_context->pressed);
+
+    if (cursor->hidden && !cursor->relative && parsec_context->pressed) {
+        parsec_context->hidden_drag = true;
+    } else if (!cursor->hidden || cursor->relative) {
+        parsec_context->hidden_drag = false;
+    }
+
     if (cursor->imageUpdate) {
         Uint8 *image = ParsecGetBuffer(parsec_context->parsec, buffer_key);
 
@@ -143,25 +171,39 @@ vdi_stream_client__cursor(
         }
     }
 
-    if (!SDL_GetWindowRelativeMouseMode(parsec_context->window) &&
-        (cursor->relative || cursor->hidden)) {
+    if (need_cursor_grab) {
+        vdi_stream_client__cursor_set_grab(parsec_context, true, grab, grab_forced);
+    }
+
+    if (cursor->hidden && (!parsec_context->hidden_drag || parsec_context->pressed)) {
         SDL_HideCursor();
+    } else {
+        SDL_ShowCursor();
+    }
+
+    if (!SDL_GetWindowRelativeMouseMode(parsec_context->window) && cursor->relative) {
         SDL_SetWindowRelativeMouseMode(parsec_context->window, true);
         if (!parsec_context->pressed && !grab_forced) {
             SDL_SetWindowTitle(
                 parsec_context->window, "VDI Stream Client (Press Ctrl+Alt to release grab)"
             );
         }
-        parsec_context->relative = cursor->relative;
-    } else if (SDL_GetWindowRelativeMouseMode(parsec_context->window) &&
-               (!cursor->relative || !cursor->hidden)) {
+    } else if (SDL_GetWindowRelativeMouseMode(parsec_context->window) && !cursor->relative) {
         SDL_SetWindowRelativeMouseMode(parsec_context->window, false);
-        SDL_ShowCursor();
+        if (!cursor->hidden) {
+            SDL_ShowCursor();
+        }
         if (!parsec_context->pressed && !grab_forced && !grab) {
             SDL_SetWindowTitle(parsec_context->window, "VDI Stream Client");
         }
-        parsec_context->relative = cursor->relative;
     }
+
+    if (!need_cursor_grab) {
+        vdi_stream_client__cursor_set_grab(parsec_context, false, grab, grab_forced);
+    }
+
+    parsec_context->hidden = cursor->hidden;
+    parsec_context->relative = cursor->relative;
 }
 
 /* render text. */
@@ -583,16 +625,17 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
                             (mouse_buttons & SDL_BUTTON_MMASK) == 0 &&
                             (mouse_buttons & SDL_BUTTON_RMASK) == 0) {
 
-                            /* check if we need to release mouse grab. */
-                            if (vdi_config->grab == 1 &&
-                                SDL_GetWindowMouseGrab(parsec_context.window)) {
-                                SDL_SetWindowMouseGrab(parsec_context.window, false);
-                            }
-
                             /* check if we need to release relative grab. */
                             if (SDL_GetWindowRelativeMouseMode(parsec_context.window)) {
                                 SDL_SetWindowRelativeMouseMode(parsec_context.window, false);
                                 SDL_ShowCursor();
+                            }
+
+                            /* check if we need to release mouse grab. */
+                            if (vdi_config->grab == 1 &&
+                                SDL_GetWindowMouseGrab(parsec_context.window)) {
+                                SDL_SetWindowMouseGrab(parsec_context.window, false);
+                                parsec_context.cursor_grab = false;
                             }
 
                             /* remove grab information from window title. */
@@ -623,6 +666,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
                             }
 
                             SDL_SetWindowMouseGrab(parsec_context.window, false);
+                            parsec_context.cursor_grab = false;
                             SDL_SetWindowTitle(parsec_context.window, "VDI Stream Client");
                             grab_forced = false;
                         } else {
@@ -636,6 +680,9 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
                             if (parsec_context.relative &&
                                 !SDL_GetWindowRelativeMouseMode(parsec_context.window)) {
                                 SDL_HideCursor();
+                                vdi_stream_client__cursor_set_grab(
+                                    &parsec_context, true, vdi_config->grab, grab_forced
+                                );
                                 SDL_SetWindowRelativeMouseMode(parsec_context.window, true);
                             }
 
@@ -681,6 +728,19 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
                 /* store mouse button state for use in cursor update. */
                 parsec_context.pressed = false;
 
+                /* keep the local cursor visible after non-relative window drags. */
+                if (parsec_context.hidden_drag && parsec_context.hidden &&
+                    !parsec_context.relative) {
+                    SDL_ShowCursor();
+                }
+
+                /* release temporary drag grab once the non-relative drag ends. */
+                if (parsec_context.hidden && !parsec_context.relative) {
+                    vdi_stream_client__cursor_set_grab(
+                        &parsec_context, false, vdi_config->grab, grab_forced
+                    );
+                }
+
                 pmsg.type = MESSAGE_MOUSE_BUTTON;
                 pmsg.mouseButton.button = msg.button.button;
                 pmsg.mouseButton.pressed = false;
@@ -703,10 +763,19 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
                     if (parsec_context.relative &&
                         !SDL_GetWindowRelativeMouseMode(parsec_context.window)) {
                         SDL_HideCursor();
+                        vdi_stream_client__cursor_set_grab(
+                            &parsec_context, true, vdi_config->grab, grab_forced
+                        );
                         SDL_SetWindowRelativeMouseMode(parsec_context.window, true);
                         SDL_SetWindowTitle(
                             parsec_context.window,
                             "VDI Stream Client (Press Ctrl+Alt to release grab)"
+                        );
+                    }
+
+                    if (parsec_context.hidden && !parsec_context.relative) {
+                        vdi_stream_client__cursor_set_grab(
+                            &parsec_context, true, vdi_config->grab, grab_forced
                         );
                     }
                 }

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -288,7 +288,7 @@ vdi_stream_client__cursor(
 
 /* render text. */
 Sint32
-vdi_stream_client__render_text(void *opaque, char *text)
+vdi_stream_client__render_text(void *opaque, const char *text)
 {
     struct parsec_context_s *parsec_context = (struct parsec_context_s *)opaque;
     SDL_Color color = { 0x88, 0x88, 0x88, 0xFF };
@@ -324,6 +324,276 @@ vdi_stream_client__render_text(void *opaque, char *text)
     return VDI_STREAM_CLIENT_SUCCESS;
 }
 
+static void
+vdi_stream_client__release_grab(struct parsec_context_s *parsec_context)
+{
+    if (SDL_GetWindowRelativeMouseMode(parsec_context->window)) {
+        SDL_SetWindowRelativeMouseMode(parsec_context->window, false);
+        SDL_ShowCursor();
+    }
+
+    if (SDL_GetWindowMouseGrab(parsec_context->window)) {
+        SDL_SetWindowMouseGrab(parsec_context->window, false);
+    }
+    parsec_context->cursor_grab = false;
+    SDL_SetWindowTitle(parsec_context->window, "VDI Stream Client");
+}
+
+static bool
+vdi_stream_client__handle_release_grab_hotkey(
+    struct parsec_context_s *parsec_context, SDL_Event *msg, bool grab_forced
+)
+{
+    SDL_MouseButtonFlags mouse_buttons;
+
+    if ((msg->key.mod & SDL_KMOD_LCTRL) == 0 || (msg->key.mod & SDL_KMOD_LALT) == 0 ||
+        grab_forced) {
+        return false;
+    }
+
+    mouse_buttons = SDL_GetMouseState(NULL, NULL);
+    if ((mouse_buttons & SDL_BUTTON_LMASK) != 0 || (mouse_buttons & SDL_BUTTON_MMASK) != 0 ||
+        (mouse_buttons & SDL_BUTTON_RMASK) != 0) {
+        return false;
+    }
+
+    vdi_stream_client__release_grab(parsec_context);
+    return true;
+}
+
+static bool
+vdi_stream_client__handle_forced_grab_hotkey(
+    struct parsec_context_s *parsec_context, struct vdi_config_s *vdi_config, SDL_Event *msg,
+    bool *grab_forced
+)
+{
+    if ((msg->key.mod & SDL_KMOD_LSHIFT) == 0 || msg->key.key != SDLK_F12) {
+        return false;
+    }
+
+    if (*grab_forced) {
+        if (vdi_config->screensaver == 1) {
+            SDL_EnableScreenSaver();
+        }
+        vdi_stream_client__release_grab(parsec_context);
+        *grab_forced = false;
+        return true;
+    }
+
+    if (vdi_config->screensaver == 1) {
+        SDL_DisableScreenSaver();
+    }
+
+    if (parsec_context->relative && !SDL_GetWindowRelativeMouseMode(parsec_context->window)) {
+        SDL_HideCursor();
+        vdi_stream_client__cursor_set_grab(parsec_context, true, vdi_config->grab, *grab_forced);
+        SDL_SetWindowRelativeMouseMode(parsec_context->window, true);
+    }
+
+    SDL_SetWindowMouseGrab(parsec_context->window, true);
+    SDL_SetWindowTitle(
+        parsec_context->window, "VDI Stream Client (Press Shift+F12 to release forced grab)"
+    );
+    *grab_forced = true;
+    return true;
+}
+
+static void
+vdi_stream_client__handle_mouse_button_down(
+    struct parsec_context_s *parsec_context, struct vdi_config_s *vdi_config, bool grab_forced
+)
+{
+    if (grab_forced) {
+        return;
+    }
+
+    if (vdi_config->grab == 1 && !SDL_GetWindowMouseGrab(parsec_context->window)) {
+        SDL_SetWindowMouseGrab(parsec_context->window, true);
+        SDL_SetWindowTitle(
+            parsec_context->window, "VDI Stream Client (Press Ctrl+Alt to release grab)"
+        );
+    }
+
+    if (parsec_context->relative && !SDL_GetWindowRelativeMouseMode(parsec_context->window)) {
+        SDL_HideCursor();
+        vdi_stream_client__cursor_set_grab(parsec_context, true, vdi_config->grab, grab_forced);
+        SDL_SetWindowRelativeMouseMode(parsec_context->window, true);
+        SDL_SetWindowTitle(
+            parsec_context->window, "VDI Stream Client (Press Ctrl+Alt to release grab)"
+        );
+    }
+
+    if (parsec_context->hidden && !parsec_context->relative) {
+        vdi_stream_client__cursor_set_grab(parsec_context, true, vdi_config->grab, grab_forced);
+    }
+}
+
+static void
+vdi_stream_client__handle_mouse_button_up(
+    struct parsec_context_s *parsec_context, struct vdi_config_s *vdi_config, bool grab_forced
+)
+{
+    if (parsec_context->hidden_drag && parsec_context->hidden && !parsec_context->relative) {
+        SDL_ShowCursor();
+    }
+
+    if (parsec_context->hidden && !parsec_context->relative) {
+        vdi_stream_client__cursor_set_grab(parsec_context, false, vdi_config->grab, grab_forced);
+    }
+}
+
+static void
+vdi_stream_client__handle_sdl_event(
+    struct parsec_context_s *parsec_context, struct vdi_config_s *vdi_config, SDL_Event *msg,
+    bool *grab_forced, bool *force_redraw
+)
+{
+    ParsecMessage pmsg = { 0 };
+
+    /* Only the overlay needs a forced redraw for arbitrary SDL events. The
+     * connected video path presents on new frames instead. */
+    if (!vdi_stream_client__context_connected(parsec_context)) {
+        *force_redraw = true;
+    }
+
+    switch (msg->type) {
+    case SDL_EVENT_QUIT:
+        vdi_stream_client__context_set_done(parsec_context, true);
+        vdi_stream_client__render_text(parsec_context, "Closing...");
+        *force_redraw = true;
+        break;
+    case SDL_EVENT_KEY_UP:
+        pmsg.type = MESSAGE_KEYBOARD;
+        pmsg.keyboard.code = (ParsecKeycode)msg->key.scancode;
+        pmsg.keyboard.mod = msg->key.mod;
+        pmsg.keyboard.pressed = false;
+        break;
+    case SDL_EVENT_KEY_DOWN:
+        if (vdi_config->grab == 1 &&
+            vdi_stream_client__handle_release_grab_hotkey(parsec_context, msg, *grab_forced)) {
+            break;
+        }
+
+        if (vdi_config->grab == 0 && vdi_stream_client__handle_forced_grab_hotkey(
+                                         parsec_context, vdi_config, msg, grab_forced
+                                     )) {
+            break;
+        }
+
+        pmsg.type = MESSAGE_KEYBOARD;
+        pmsg.keyboard.code = (ParsecKeycode)msg->key.scancode;
+        pmsg.keyboard.mod = msg->key.mod;
+        pmsg.keyboard.pressed = true;
+        break;
+    case SDL_EVENT_MOUSE_MOTION:
+    {
+        bool relative_mouse = SDL_GetWindowRelativeMouseMode(parsec_context->window);
+
+        if (parsec_context->relative && !relative_mouse) {
+            break;
+        }
+
+        pmsg.type = MESSAGE_MOUSE_MOTION;
+        pmsg.mouseMotion.relative = relative_mouse;
+        pmsg.mouseMotion.x = relative_mouse ? (Sint32)msg->motion.xrel : (Sint32)msg->motion.x + 1;
+        pmsg.mouseMotion.y = relative_mouse ? (Sint32)msg->motion.yrel : (Sint32)msg->motion.y + 1;
+        break;
+    }
+    case SDL_EVENT_MOUSE_BUTTON_UP:
+        parsec_context->pressed = false;
+        vdi_stream_client__handle_mouse_button_up(parsec_context, vdi_config, *grab_forced);
+        pmsg.type = MESSAGE_MOUSE_BUTTON;
+        pmsg.mouseButton.button = msg->button.button;
+        pmsg.mouseButton.pressed = false;
+        break;
+    case SDL_EVENT_MOUSE_BUTTON_DOWN:
+        vdi_stream_client__handle_mouse_button_down(parsec_context, vdi_config, *grab_forced);
+        parsec_context->pressed = true;
+        pmsg.type = MESSAGE_MOUSE_BUTTON;
+        pmsg.mouseButton.button = msg->button.button;
+        pmsg.mouseButton.pressed = true;
+        break;
+    case SDL_EVENT_MOUSE_WHEEL:
+        pmsg.type = MESSAGE_MOUSE_WHEEL;
+        pmsg.mouseWheel.x = msg->wheel.x * vdi_config->speed;
+        pmsg.mouseWheel.y = msg->wheel.y * vdi_config->speed;
+        break;
+    case SDL_EVENT_CLIPBOARD_UPDATE:
+        if (vdi_config->clipboard == 1) {
+            char *clipboard = SDL_GetClipboardText();
+
+            if (clipboard != NULL) {
+                ParsecClientSendUserData(parsec_context->parsec, PARSEC_CLIPBOARD_MSG, clipboard);
+                SDL_free(clipboard);
+            }
+        }
+        break;
+    case SDL_EVENT_WINDOW_MOUSE_ENTER:
+        SDL_SetEventEnabled(SDL_EVENT_KEY_DOWN, true);
+        SDL_SetEventEnabled(SDL_EVENT_KEY_UP, true);
+        SDL_SetWindowKeyboardGrab(parsec_context->window, true);
+        break;
+    case SDL_EVENT_WINDOW_MOUSE_LEAVE:
+        SDL_SetEventEnabled(SDL_EVENT_KEY_DOWN, false);
+        SDL_SetEventEnabled(SDL_EVENT_KEY_UP, false);
+        SDL_SetWindowKeyboardGrab(parsec_context->window, false);
+        break;
+    }
+
+    if (pmsg.type != 0) {
+        ParsecClientSendMessage(parsec_context->parsec, &pmsg);
+    }
+}
+
+static void
+vdi_stream_client__show_connection_overlay(
+    struct parsec_context_s *parsec_context, bool *force_redraw, const char *text
+)
+{
+    vdi_stream_client__render_text(parsec_context, text);
+    *force_redraw = true;
+}
+
+static ParsecStatus
+vdi_stream_client__handle_connection_status(
+    struct parsec_context_s *parsec_context, struct vdi_config_s *vdi_config,
+    ParsecClientConfig *cfg, Uint64 *last_time, bool *force_redraw
+)
+{
+    ParsecStatus e = ParsecClientGetStatus(parsec_context->parsec, &parsec_context->client_status);
+
+    if (vdi_config->reconnect == 0 && e != PARSEC_CONNECTING && e != PARSEC_OK) {
+        vdi_stream_client__show_connection_overlay(parsec_context, force_redraw, "Closing...");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Parsec disconnected\n");
+        vdi_stream_client__context_set_done(parsec_context, true);
+    }
+    if (vdi_config->reconnect == 1 && e != PARSEC_CONNECTING && e != PARSEC_OK &&
+        SDL_GetTicks() > *last_time + vdi_config->timeout) {
+        vdi_stream_client__show_connection_overlay(parsec_context, force_redraw, "Reconnecting...");
+        e = vdi_stream_client__parsec_reconnect(parsec_context, cfg, vdi_config);
+        *last_time = SDL_GetTicks();
+    }
+
+    if (vdi_config->reconnect == 0 && parsec_context->client_status.networkFailure == 1) {
+        vdi_stream_client__show_connection_overlay(parsec_context, force_redraw, "Closing...");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Network disconnected\n");
+        vdi_stream_client__context_set_done(parsec_context, true);
+    }
+    if (vdi_config->reconnect == 1 && parsec_context->client_status.networkFailure == 1 &&
+        SDL_GetTicks() > *last_time + vdi_config->timeout) {
+        vdi_stream_client__show_connection_overlay(parsec_context, force_redraw, "Reconnecting...");
+        e = vdi_stream_client__parsec_reconnect(parsec_context, cfg, vdi_config);
+        *last_time = SDL_GetTicks();
+    }
+
+    if (vdi_config->reconnect == 1 && parsec_context->client_status.networkFailure == 0 &&
+        e == PARSEC_OK && !vdi_stream_client__context_connected(parsec_context)) {
+        vdi_stream_client__context_set_connection(parsec_context, true);
+    }
+
+    return e;
+}
+
 /* parsec event loop. */
 Sint32
 vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
@@ -334,8 +604,6 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     Uint32 wait_time = 0;
     Uint64 last_time = 0;
     bool force_redraw = false;
-    float x = 0.0f;
-    float y = 0.0f;
     SDL_AudioSpec want = { 0 };
     ParsecStatus e;
     ParsecConfig network_cfg = PARSEC_DEFAULTS;
@@ -661,289 +929,19 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
             if (parsec_context.stats_enabled) {
                 parsec_context.stats_sdl_events++;
             }
-            ParsecMessage pmsg = { 0 };
             local_interaction = true;
-
-            /* Only the overlay needs a forced redraw for arbitrary SDL events; the
-             * connected video path should present on new frames instead of repainting
-             * the same texture for every keyboard/mouse event. */
-            if (!vdi_stream_client__context_connected(&parsec_context)) {
-                force_redraw = true;
-            }
-
-            switch (msg.type) {
-            case SDL_EVENT_QUIT:
-                vdi_stream_client__context_set_done(&parsec_context, true);
-
-                /* render shutdown text. */
-                vdi_stream_client__render_text(&parsec_context, "Closing...");
-                force_redraw = true;
-                break;
-            case SDL_EVENT_KEY_UP:
-                pmsg.type = MESSAGE_KEYBOARD;
-                pmsg.keyboard.code = (ParsecKeycode)msg.key.scancode;
-                pmsg.keyboard.mod = msg.key.mod;
-                pmsg.keyboard.pressed = false;
-                break;
-            case SDL_EVENT_KEY_DOWN:
-
-                /* check if we need to switch window grab state. */
-                if (vdi_config->grab == 1 && (msg.key.mod & SDL_KMOD_LCTRL) != 0 &&
-                    (msg.key.mod & SDL_KMOD_LALT) != 0) {
-
-                    /* check if no forced grab. */
-                    if (!grab_forced) {
-
-                        /* check if no mouse button is hold down. */
-                        SDL_MouseButtonFlags mouse_buttons = SDL_GetMouseState(NULL, NULL);
-                        if ((mouse_buttons & SDL_BUTTON_LMASK) == 0 &&
-                            (mouse_buttons & SDL_BUTTON_MMASK) == 0 &&
-                            (mouse_buttons & SDL_BUTTON_RMASK) == 0) {
-
-                            /* check if we need to release relative grab. */
-                            if (SDL_GetWindowRelativeMouseMode(parsec_context.window)) {
-                                SDL_SetWindowRelativeMouseMode(parsec_context.window, false);
-                                SDL_ShowCursor();
-                            }
-
-                            /* check if we need to release mouse grab. */
-                            if (vdi_config->grab == 1 &&
-                                SDL_GetWindowMouseGrab(parsec_context.window)) {
-                                SDL_SetWindowMouseGrab(parsec_context.window, false);
-                                parsec_context.cursor_grab = false;
-                            }
-
-                            /* remove grab information from window title. */
-                            SDL_SetWindowTitle(parsec_context.window, "VDI Stream Client");
-
-                            /* don't send hotkey to host and break execution. */
-                            break;
-                        }
-                    }
-                }
-
-                /* check if we need to toggle runtime configuration. */
-                if (vdi_config->grab == 0 && (msg.key.mod & SDL_KMOD_LSHIFT) != 0) {
-
-                    /* check if we need to toggle forced grab. */
-                    if (msg.key.key == SDLK_F12) {
-                        if (grab_forced) {
-
-                            /* re-enable screensaver if leaving forced lock. */
-                            if (vdi_config->screensaver == 1) {
-                                SDL_EnableScreenSaver();
-                            }
-
-                            /* check if we need to release relative grab. */
-                            if (SDL_GetWindowRelativeMouseMode(parsec_context.window)) {
-                                SDL_SetWindowRelativeMouseMode(parsec_context.window, false);
-                                SDL_ShowCursor();
-                            }
-
-                            SDL_SetWindowMouseGrab(parsec_context.window, false);
-                            parsec_context.cursor_grab = false;
-                            SDL_SetWindowTitle(parsec_context.window, "VDI Stream Client");
-                            grab_forced = false;
-                        } else {
-
-                            /* disable screensaver if entering forced lock. */
-                            if (vdi_config->screensaver == 1) {
-                                SDL_DisableScreenSaver();
-                            }
-
-                            /* check if we need to grab mouse in relative mode. */
-                            if (parsec_context.relative &&
-                                !SDL_GetWindowRelativeMouseMode(parsec_context.window)) {
-                                SDL_HideCursor();
-                                vdi_stream_client__cursor_set_grab(
-                                    &parsec_context, true, vdi_config->grab, grab_forced
-                                );
-                                SDL_SetWindowRelativeMouseMode(parsec_context.window, true);
-                            }
-
-                            SDL_SetWindowMouseGrab(parsec_context.window, true);
-                            SDL_SetWindowTitle(
-                                parsec_context.window,
-                                "VDI Stream Client (Press Shift+F12 to release forced grab)"
-                            );
-                            grab_forced = true;
-                        }
-
-                        /* don't send hotkey to host and break execution. */
-                        break;
-                    }
-                }
-
-                pmsg.type = MESSAGE_KEYBOARD;
-                pmsg.keyboard.code = (ParsecKeycode)msg.key.scancode;
-                pmsg.keyboard.mod = msg.key.mod;
-                pmsg.keyboard.pressed = true;
-                break;
-            case SDL_EVENT_MOUSE_MOTION:
-            {
-                bool relative_mouse = SDL_GetWindowRelativeMouseMode(parsec_context.window);
-
-                /* check if we released relative mouse grab. */
-                if (parsec_context.relative && !relative_mouse) {
-
-                    /* no mouse motion events should be forwarded. */
-                    break;
-                }
-
-                pmsg.type = MESSAGE_MOUSE_MOTION;
-                pmsg.mouseMotion.relative = relative_mouse;
-                pmsg.mouseMotion.x =
-                    relative_mouse ? (Sint32)msg.motion.xrel : (Sint32)msg.motion.x + 1;
-                pmsg.mouseMotion.y =
-                    relative_mouse ? (Sint32)msg.motion.yrel : (Sint32)msg.motion.y + 1;
-                break;
-            }
-            case SDL_EVENT_MOUSE_BUTTON_UP:
-
-                /* store mouse button state for use in cursor update. */
-                parsec_context.pressed = false;
-
-                /* keep the local cursor visible after non-relative window drags. */
-                if (parsec_context.hidden_drag && parsec_context.hidden &&
-                    !parsec_context.relative) {
-                    SDL_ShowCursor();
-                }
-
-                /* release temporary drag grab once the non-relative drag ends. */
-                if (parsec_context.hidden && !parsec_context.relative) {
-                    vdi_stream_client__cursor_set_grab(
-                        &parsec_context, false, vdi_config->grab, grab_forced
-                    );
-                }
-
-                pmsg.type = MESSAGE_MOUSE_BUTTON;
-                pmsg.mouseButton.button = msg.button.button;
-                pmsg.mouseButton.pressed = false;
-                break;
-            case SDL_EVENT_MOUSE_BUTTON_DOWN:
-
-                /* check if no forced grab. */
-                if (!grab_forced) {
-
-                    /* check if we need to grab mouse. */
-                    if (vdi_config->grab == 1 && !SDL_GetWindowMouseGrab(parsec_context.window)) {
-                        SDL_SetWindowMouseGrab(parsec_context.window, true);
-                        SDL_SetWindowTitle(
-                            parsec_context.window,
-                            "VDI Stream Client (Press Ctrl+Alt to release grab)"
-                        );
-                    }
-
-                    /* check if we need to grab mouse in relative mode. */
-                    if (parsec_context.relative &&
-                        !SDL_GetWindowRelativeMouseMode(parsec_context.window)) {
-                        SDL_HideCursor();
-                        vdi_stream_client__cursor_set_grab(
-                            &parsec_context, true, vdi_config->grab, grab_forced
-                        );
-                        SDL_SetWindowRelativeMouseMode(parsec_context.window, true);
-                        SDL_SetWindowTitle(
-                            parsec_context.window,
-                            "VDI Stream Client (Press Ctrl+Alt to release grab)"
-                        );
-                    }
-
-                    if (parsec_context.hidden && !parsec_context.relative) {
-                        vdi_stream_client__cursor_set_grab(
-                            &parsec_context, true, vdi_config->grab, grab_forced
-                        );
-                    }
-                }
-
-                /* store mouse button state for use in cursor update. */
-                parsec_context.pressed = true;
-
-                pmsg.type = MESSAGE_MOUSE_BUTTON;
-                pmsg.mouseButton.button = msg.button.button;
-                pmsg.mouseButton.pressed = true;
-                break;
-            case SDL_EVENT_MOUSE_WHEEL:
-                pmsg.type = MESSAGE_MOUSE_WHEEL;
-                pmsg.mouseWheel.x = msg.wheel.x * vdi_config->speed;
-                pmsg.mouseWheel.y = msg.wheel.y * vdi_config->speed;
-                break;
-            case SDL_EVENT_CLIPBOARD_UPDATE:
-                if (vdi_config->clipboard == 1) {
-                    char *clipboard = SDL_GetClipboardText();
-
-                    if (clipboard != NULL) {
-                        ParsecClientSendUserData(
-                            parsec_context.parsec, PARSEC_CLIPBOARD_MSG, clipboard
-                        );
-                        SDL_free(clipboard);
-                    }
-                }
-                break;
-            case SDL_EVENT_WINDOW_MOUSE_ENTER:
-                SDL_SetEventEnabled(SDL_EVENT_KEY_DOWN, true);
-                SDL_SetEventEnabled(SDL_EVENT_KEY_UP, true);
-                SDL_SetWindowKeyboardGrab(parsec_context.window, true);
-                break;
-            case SDL_EVENT_WINDOW_MOUSE_LEAVE:
-                SDL_SetEventEnabled(SDL_EVENT_KEY_DOWN, false);
-                SDL_SetEventEnabled(SDL_EVENT_KEY_UP, false);
-                SDL_SetWindowKeyboardGrab(parsec_context.window, false);
-                break;
-            }
-
-            if (pmsg.type != 0) {
-                ParsecClientSendMessage(parsec_context.parsec, &pmsg);
-            }
+            vdi_stream_client__handle_sdl_event(
+                &parsec_context, vdi_config, &msg, &grab_forced, &force_redraw
+            );
         }
 
         /* prioritize SDL responsiveness after local interaction without forcing
          * redundant presents of the last video frame. */
         parsec_context.render_timeout = local_interaction ? 0 : 5;
 
-        /* check parsec connection status. */
-        e = ParsecClientGetStatus(parsec_context.parsec, &parsec_context.client_status);
-        if (vdi_config->reconnect == 0 && e != PARSEC_CONNECTING && e != PARSEC_OK) {
-
-            /* render shutdown text. */
-            vdi_stream_client__render_text(&parsec_context, "Closing...");
-            force_redraw = true;
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Parsec disconnected\n");
-            vdi_stream_client__context_set_done(&parsec_context, true);
-        }
-        if (vdi_config->reconnect == 1 && e != PARSEC_CONNECTING && e != PARSEC_OK &&
-            SDL_GetTicks() > last_time + vdi_config->timeout) {
-
-            /* render reconnect text. */
-            vdi_stream_client__render_text(&parsec_context, "Reconnecting...");
-            force_redraw = true;
-            e = vdi_stream_client__parsec_reconnect(&parsec_context, &cfg, vdi_config);
-            last_time = SDL_GetTicks();
-        }
-
-        /* check network connection status. */
-        if (vdi_config->reconnect == 0 && parsec_context.client_status.networkFailure == 1) {
-
-            /* render shutdown text. */
-            vdi_stream_client__render_text(&parsec_context, "Closing...");
-            force_redraw = true;
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Network disconnected\n");
-            vdi_stream_client__context_set_done(&parsec_context, true);
-        }
-        if (vdi_config->reconnect == 1 && parsec_context.client_status.networkFailure == 1 &&
-            SDL_GetTicks() > last_time + vdi_config->timeout) {
-
-            /* render reconnect text. */
-            vdi_stream_client__render_text(&parsec_context, "Reconnecting...");
-            force_redraw = true;
-            e = vdi_stream_client__parsec_reconnect(&parsec_context, &cfg, vdi_config);
-            last_time = SDL_GetTicks();
-        }
-
-        /* set connection status if reconnected. */
-        if (vdi_config->reconnect == 1 && parsec_context.client_status.networkFailure == 0 &&
-            e == PARSEC_OK && !vdi_stream_client__context_connected(&parsec_context)) {
-            vdi_stream_client__context_set_connection(&parsec_context, true);
-        }
+        e = vdi_stream_client__handle_connection_status(
+            &parsec_context, vdi_config, &cfg, &last_time, &force_redraw
+        );
 
         for (ParsecClientEvent event; ParsecClientPollEvents(parsec_context.parsec, 0, &event);) {
             if (parsec_context.stats_enabled) {

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -334,6 +334,15 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
         goto error;
     }
 
+    /* configure upnp before parsec init consumes the network configuration. */
+    if (vdi_config->upnp == 1) {
+        network_cfg.upnp = 1;
+    }
+    if (vdi_config->upnp == 0) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Disable UPnP\n");
+        network_cfg.upnp = 0;
+    }
+
     /* parsec init. */
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Initialize Parsec\n");
 #ifdef HAVE_LIBPARSEC
@@ -390,15 +399,6 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     if (vdi_config->acceleration == 0) {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Disable Hardware Accelerated Video Decoding\n");
         cfg.video[DEFAULT_STREAM].decoderIndex = 0;
-    }
-
-    /* configure upnp. */
-    if (vdi_config->upnp == 1) {
-        network_cfg.upnp = 1;
-    }
-    if (vdi_config->upnp == 0) {
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Disable UPnP\n");
-        network_cfg.upnp = 0;
     }
 
     /* check if reconnect should be disabled. */

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -108,6 +108,44 @@ vdi_stream_client__render_stats(struct parsec_context_s *parsec_context)
     parsec_context->stats_idle_wait_ms = 0;
 }
 
+/* signal worker threads and wait until they stop using shared runtime resources. */
+static void
+vdi_stream_client__stop_threads(
+    struct parsec_context_s *parsec_context, SDL_Thread **audio_thread,
+    SDL_Thread *network_thread[USB_MAX], Uint32 usb_count
+)
+{
+    bool network_started = false;
+
+    vdi_stream_client__context_set_done(parsec_context, true);
+
+    if (usb_count > 0) {
+        for (Uint32 count = 0; count < usb_count; count++) {
+            if (network_thread[count] != NULL) {
+                network_started = true;
+                break;
+            }
+        }
+    }
+
+    if (network_started) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Stop Network Thread\n");
+        for (Uint32 count = 0; count < usb_count; count++) {
+            if (network_thread[count] == NULL) {
+                continue;
+            }
+            SDL_WaitThread(network_thread[count], NULL);
+            network_thread[count] = NULL;
+        }
+    }
+
+    if (*audio_thread != NULL) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Stop Audio Thread\n");
+        SDL_WaitThread(*audio_thread, NULL);
+        *audio_thread = NULL;
+    }
+}
+
 /* keep cursor-induced grabs separate from user-requested grabs. */
 static void
 vdi_stream_client__cursor_set_grab(
@@ -261,7 +299,6 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     ParsecConfig network_cfg = PARSEC_DEFAULTS;
     ParsecClientConfig cfg = PARSEC_CLIENT_DEFAULTS;
     Uint32 device;
-    Uint32 count;
     SDL_Thread *audio_thread = NULL;
     SDL_Thread *network_thread[USB_MAX] = { 0 };
     SDL_WindowFlags window_flags = SDL_WINDOW_HIGH_PIXEL_DENSITY;
@@ -420,9 +457,9 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
             /* decoder not yet initialized. */
             if (parsec_context.client_status.decoder[DEFAULT_STREAM].width == 0 &&
                 parsec_context.client_status.decoder[DEFAULT_STREAM].height == 0 &&
-                !parsec_context.connection) {
+                !vdi_stream_client__context_connected(&parsec_context)) {
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Initialize Video Decoder\n");
-                parsec_context.connection = true;
+                vdi_stream_client__context_set_connection(&parsec_context, true);
             }
 
             /* decoder initialized. */
@@ -475,7 +512,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     );
 
     /* check if connected and decoder initialized. */
-    if (!parsec_context.connection && !parsec_context.decoder) {
+    if (!parsec_context.decoder) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Connection failed with code: %d\n", e);
         goto error;
     }
@@ -564,7 +601,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     }
 
     /* event loop. */
-    while (!parsec_context.done) {
+    while (!vdi_stream_client__context_done(&parsec_context)) {
         Uint64 loop_sdl_events = 0;
         Uint64 loop_parsec_events = 0;
         Uint64 loop_frames = 0;
@@ -592,13 +629,13 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
             /* Only the overlay needs a forced redraw for arbitrary SDL events; the
              * connected video path should present on new frames instead of repainting
              * the same texture for every keyboard/mouse event. */
-            if (!parsec_context.connection) {
+            if (!vdi_stream_client__context_connected(&parsec_context)) {
                 force_redraw = true;
             }
 
             switch (msg.type) {
             case SDL_EVENT_QUIT:
-                parsec_context.done = true;
+                vdi_stream_client__context_set_done(&parsec_context, true);
 
                 /* render shutdown text. */
                 vdi_stream_client__render_text(&parsec_context, "Closing...");
@@ -833,7 +870,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
             vdi_stream_client__render_text(&parsec_context, "Closing...");
             force_redraw = true;
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Parsec disconnected\n");
-            parsec_context.done = true;
+            vdi_stream_client__context_set_done(&parsec_context, true);
         }
         if (vdi_config->reconnect == 1 && e != PARSEC_CONNECTING && e != PARSEC_OK &&
             SDL_GetTicks() > last_time + vdi_config->timeout) {
@@ -843,7 +880,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
             force_redraw = true;
             ParsecClientDisconnect(parsec_context.parsec);
             ParsecClientConnect(parsec_context.parsec, &cfg, vdi_config->session, vdi_config->peer);
-            parsec_context.connection = false;
+            vdi_stream_client__context_set_connection(&parsec_context, false);
             last_time = SDL_GetTicks();
         }
 
@@ -854,7 +891,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
             vdi_stream_client__render_text(&parsec_context, "Closing...");
             force_redraw = true;
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Network disconnected\n");
-            parsec_context.done = true;
+            vdi_stream_client__context_set_done(&parsec_context, true);
         }
         if (vdi_config->reconnect == 1 && parsec_context.client_status.networkFailure == 1 &&
             SDL_GetTicks() > last_time + vdi_config->timeout) {
@@ -864,14 +901,14 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
             force_redraw = true;
             ParsecClientDisconnect(parsec_context.parsec);
             ParsecClientConnect(parsec_context.parsec, &cfg, vdi_config->session, vdi_config->peer);
-            parsec_context.connection = false;
+            vdi_stream_client__context_set_connection(&parsec_context, false);
             last_time = SDL_GetTicks();
         }
 
         /* set connection status if reconnected. */
         if (vdi_config->reconnect == 1 && parsec_context.client_status.networkFailure == 0 &&
-            e == PARSEC_OK && !parsec_context.connection) {
-            parsec_context.connection = true;
+            e == PARSEC_OK && !vdi_stream_client__context_connected(&parsec_context)) {
+            vdi_stream_client__context_set_connection(&parsec_context, true);
         }
 
         for (ParsecClientEvent event; ParsecClientPollEvents(parsec_context.parsec, 0, &event);) {
@@ -933,7 +970,8 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
          * frame delivery. When disconnected, no frame source is blocking this
          * loop, so keep a small coarse idle sleep to avoid busy-spinning while
          * reconnecting or showing the overlay. */
-        if (!parsec_context.connection && !rendered && parsec_context.render_timeout > 0) {
+        if (!vdi_stream_client__context_connected(&parsec_context) && !rendered &&
+            parsec_context.render_timeout > 0) {
             SDL_Delay(parsec_context.render_timeout);
         }
 
@@ -952,22 +990,9 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     SDL_SetWindowMouseGrab(parsec_context.window, false);
     SDL_SetWindowKeyboardGrab(parsec_context.window, false);
 
-    /* stop network threads for usb redirection. */
-    if (vdi_config->usb_count > 0) {
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Stop Network Thread\n");
-        for (count = 0; count < vdi_config->usb_count; count++) {
-            if (network_thread[count] == NULL) {
-                continue;
-            }
-            SDL_WaitThread(network_thread[count], NULL);
-        }
-    }
-
-    /* stop audio thread. */
-    if (vdi_config->audio == 1) {
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Stop Audio Thread\n");
-        SDL_WaitThread(audio_thread, NULL);
-    }
+    vdi_stream_client__stop_threads(
+        &parsec_context, &audio_thread, network_thread, vdi_config->usb_count
+    );
 
     /* destroy video resources before releasing the parsec client. */
     vdi_stream_client__video_destroy(&parsec_context);
@@ -991,6 +1016,10 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     return VDI_STREAM_CLIENT_SUCCESS;
 
 error:
+
+    vdi_stream_client__stop_threads(
+        &parsec_context, &audio_thread, network_thread, vdi_config->usb_count
+    );
 
     /* destroy video resources before releasing the parsec client. */
     vdi_stream_client__video_destroy(&parsec_context);

--- a/src/parsec.h
+++ b/src/parsec.h
@@ -29,6 +29,7 @@
 #endif
 
 /* system includes. */
+#include <stdatomic.h>
 #include <stdbool.h>
 
 /* parsec includes. */
@@ -61,8 +62,8 @@ struct parsec_context_s
 {
 
     /* parsec. */
-    bool done;
-    bool connection;
+    atomic_bool done;
+    atomic_bool connection;
     bool decoder;
     bool focus;
     bool hidden;
@@ -98,7 +99,7 @@ struct parsec_context_s
 
     /* audio. */
     SDL_AudioStream *audio;
-    bool playing;
+    atomic_bool playing;
     Uint32 min_buffer;
     Uint32 max_buffer;
 
@@ -120,6 +121,42 @@ struct parsec_context_s
     Uint64 stats_idle_waits;
     Uint64 stats_idle_wait_ms;
 };
+
+static inline bool
+vdi_stream_client__context_done(struct parsec_context_s *parsec_context)
+{
+    return atomic_load_explicit(&parsec_context->done, memory_order_acquire);
+}
+
+static inline void
+vdi_stream_client__context_set_done(struct parsec_context_s *parsec_context, bool done)
+{
+    atomic_store_explicit(&parsec_context->done, done, memory_order_release);
+}
+
+static inline bool
+vdi_stream_client__context_connected(struct parsec_context_s *parsec_context)
+{
+    return atomic_load_explicit(&parsec_context->connection, memory_order_acquire);
+}
+
+static inline void
+vdi_stream_client__context_set_connection(struct parsec_context_s *parsec_context, bool connection)
+{
+    atomic_store_explicit(&parsec_context->connection, connection, memory_order_release);
+}
+
+static inline bool
+vdi_stream_client__context_playing(struct parsec_context_s *parsec_context)
+{
+    return atomic_load_explicit(&parsec_context->playing, memory_order_acquire);
+}
+
+static inline void
+vdi_stream_client__context_set_playing(struct parsec_context_s *parsec_context, bool playing)
+{
+    atomic_store_explicit(&parsec_context->playing, playing, memory_order_release);
+}
 
 /* usb redirect. */
 struct redirect_context_s

--- a/src/parsec.h
+++ b/src/parsec.h
@@ -100,6 +100,7 @@ struct parsec_context_s
     /* audio. */
     SDL_AudioStream *audio;
     atomic_bool playing;
+    atomic_bool audio_polling;
     Uint32 min_buffer;
     Uint32 max_buffer;
 
@@ -156,6 +157,20 @@ static inline void
 vdi_stream_client__context_set_playing(struct parsec_context_s *parsec_context, bool playing)
 {
     atomic_store_explicit(&parsec_context->playing, playing, memory_order_release);
+}
+
+static inline bool
+vdi_stream_client__context_audio_polling(struct parsec_context_s *parsec_context)
+{
+    return atomic_load_explicit(&parsec_context->audio_polling, memory_order_acquire);
+}
+
+static inline void
+vdi_stream_client__context_set_audio_polling(
+    struct parsec_context_s *parsec_context, bool audio_polling
+)
+{
+    atomic_store_explicit(&parsec_context->audio_polling, audio_polling, memory_order_release);
 }
 
 /* usb redirect. */

--- a/src/parsec.h
+++ b/src/parsec.h
@@ -65,7 +65,10 @@ struct parsec_context_s
     bool connection;
     bool decoder;
     bool focus;
+    bool hidden;
+    bool hidden_drag;
     bool relative;
+    bool cursor_grab;
     bool pressed;
 #ifdef HAVE_LIBPARSEC
     Parsec *parsec;

--- a/src/redirect.c
+++ b/src/redirect.c
@@ -271,7 +271,10 @@ vdi_stream_client__network_thread(void *opaque)
             /* find device to open. */
             count = 0;
             while ((device = devices[count++]) != NULL) {
-                libusb_get_device_descriptor(device, &desc);
+                error = libusb_get_device_descriptor(device, &desc);
+                if (error != 0) {
+                    continue;
+                }
                 if (desc.idVendor == redirect_context->usb_device.vendor &&
                     desc.idProduct == redirect_context->usb_device.product) {
                     break;

--- a/src/redirect.c
+++ b/src/redirect.c
@@ -183,14 +183,14 @@ vdi_stream_client__network_thread(void *opaque)
     }
     callback_registered = 1;
 
-    while (!redirect_context->parsec_context->done) {
+    while (!vdi_stream_client__context_done(redirect_context->parsec_context)) {
         timeout = default_timeout;
 
         /* try until connection established or application quits. */
         while (server_fd == -1) {
 
             /* check if main thread is still running. */
-            if (redirect_context->parsec_context->done) {
+            if (vdi_stream_client__context_done(redirect_context->parsec_context)) {
                 break;
             }
 
@@ -251,7 +251,7 @@ vdi_stream_client__network_thread(void *opaque)
         while (host == NULL) {
 
             /* check if main thread is still running. */
-            if (redirect_context->parsec_context->done) {
+            if (vdi_stream_client__context_done(redirect_context->parsec_context)) {
                 break;
             }
 
@@ -330,7 +330,7 @@ vdi_stream_client__network_thread(void *opaque)
         while (server_fd != -1) {
 
             /* check if main thread is still running. */
-            if (redirect_context->parsec_context->done) {
+            if (vdi_stream_client__context_done(redirect_context->parsec_context)) {
                 break;
             }
 
@@ -458,7 +458,7 @@ vdi_stream_client__network_thread(void *opaque)
 error:
 
     /* stop main thread. */
-    redirect_context->parsec_context->done = true;
+    vdi_stream_client__context_set_done(redirect_context->parsec_context, true);
 
     /* close client socket. */
     if (server_fd != -1) {

--- a/src/redirect.c
+++ b/src/redirect.c
@@ -127,6 +127,7 @@ vdi_stream_client__network_thread(void *opaque)
     libusb_hotplug_callback_handle callback_handle = 0;
     struct libusb_device_descriptor desc;
     size_t count;
+    ssize_t device_count;
     Sint32 flag;
     Sint32 callback_registered = 0;
     struct sockaddr *server_addr;
@@ -256,7 +257,16 @@ vdi_stream_client__network_thread(void *opaque)
             }
 
             /* get list of usb devices. */
-            libusb_get_device_list(usb_context, &devices);
+            device_count = libusb_get_device_list(usb_context, &devices);
+            if (device_count < 0) {
+                SDL_LogError(
+                    SDL_LOG_CATEGORY_APPLICATION, "USB Device %04x:%04x scan failed: %s\n",
+                    redirect_context->usb_device.vendor, redirect_context->usb_device.product,
+                    libusb_strerror((Sint32)device_count)
+                );
+                SDL_Delay(delay);
+                continue;
+            }
 
             /* find device to open. */
             count = 0;
@@ -309,6 +319,10 @@ vdi_stream_client__network_thread(void *opaque)
                 vdi_stream_client__usb_write, NULL, NULL, 0, 0
             );
             if (host == NULL) {
+
+                /* close device handle if usbredir host setup failed. */
+                libusb_close(device_handle);
+                device_handle = NULL;
 
                 /* wait some time before rescan for usb device. */
                 SDL_Delay(delay);
@@ -464,6 +478,16 @@ error:
     if (server_fd != -1) {
         close(server_fd);
         server_fd = -1;
+    }
+
+    /* usbredirhost_close() calls libusb_close() so close either host or handle. */
+    if (host != NULL) {
+        usbredirhost_close(host);
+        device_handle = NULL;
+        host = NULL;
+    } else if (device_handle != NULL) {
+        libusb_close(device_handle);
+        device_handle = NULL;
     }
 
     /* usb destroy. */

--- a/src/video.c
+++ b/src/video.c
@@ -174,16 +174,21 @@ static bool
 vdi_stream_client__frame_video(void *opaque, bool force_redraw)
 {
     struct parsec_context_s *parsec_context = (struct parsec_context_s *)opaque;
+    ParsecStatus e;
     SDL_FRect src;
 
     if (parsec_context->requested_width != parsec_context->window_width ||
         parsec_context->requested_height != parsec_context->window_height) {
-        ParsecClientSetDimensions(
+        e = ParsecClientSetDimensions(
             parsec_context->parsec, DEFAULT_STREAM, parsec_context->window_width,
             parsec_context->window_height, 1
         );
-        parsec_context->requested_width = parsec_context->window_width;
-        parsec_context->requested_height = parsec_context->window_height;
+        if (e != PARSEC_OK) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Set dimensions failed with code: %d\n", e);
+        } else {
+            parsec_context->requested_width = parsec_context->window_width;
+            parsec_context->requested_height = parsec_context->window_height;
+        }
     }
 
     parsec_context->frame_video_updated = false;

--- a/src/video.c
+++ b/src/video.c
@@ -228,7 +228,7 @@ vdi_stream_client__video_render(struct parsec_context_s *parsec_context, bool fo
 {
 
     /* show parsec frame. */
-    if (parsec_context->connection) {
+    if (vdi_stream_client__context_connected(parsec_context)) {
         if (!vdi_stream_client__frame_video(parsec_context, force_redraw)) {
             return false;
         }

--- a/tools/parsec-login
+++ b/tools/parsec-login
@@ -67,13 +67,13 @@ function parsec_login__version() {
 }
 
 # check if curl exist.
-[ -x "/bin/curl" ] || [ -x "/usr/bin/curl" ] || [ -x "/usr/local/bin/curl" ] || {
+GLOBAL__curl="$(command -v curl)" || {
 	printf "No curl found, please install it\n"
 	exit 1
 }
 
 # check if jq exist.
-[ -x "/bin/jq" ] || [ -x "/usr/bin/jq" ] || [ -x "/usr/local/bin/jq" ] || {
+GLOBAL__jq="$(command -v jq)" || {
 	printf "No jq found, please install it\n"
 	exit 1
 }
@@ -191,7 +191,7 @@ done
 
 # check if we need to ask for 2fa code.
 [ -z "${GLOBAL__tfa}" ] && {
-	[ "$(/bin/curl --max-time 5 --silent --fail --request POST --write-out '{ "session_id":"%{http_code}" }' --header 'Content-Type: application/json' --data-binary '{ "email": "'"${GLOBAL__username}"'" , "password": "'"${GLOBAL__password}"'" }' "${PARSEC_HOST}/v1/auth" | /bin/jq --raw-output '.session_id')" == "403" ] && {
+	[ "$("${GLOBAL__curl}" --max-time 5 --silent --fail --request POST --write-out '{ "session_id":"%{http_code}" }' --header 'Content-Type: application/json' --data-binary '{ "email": "'"${GLOBAL__username}"'" , "password": "'"${GLOBAL__password}"'" }' "${PARSEC_HOST}/v1/auth" | "${GLOBAL__jq}" --raw-output '.session_id')" == "403" ] && {
 
 		# ask for 2fa code.
 		read -r -p "2FA code: " GLOBAL__tfa
@@ -206,7 +206,7 @@ done
 printf "Retrieve Session ID: "
 
 # get session id.
-/bin/curl --max-time 5 --silent --fail --request POST --header 'Content-Type: application/json' --data-binary '{ "email": "'"${GLOBAL__username}"'" , "password": "'"${GLOBAL__password}"'" , "tfa": "'"${GLOBAL__tfa}"'" }' "${PARSEC_HOST}/v1/auth" | /bin/jq --raw-output '.session_id' | {
+"${GLOBAL__curl}" --max-time 5 --silent --fail --request POST --header 'Content-Type: application/json' --data-binary '{ "email": "'"${GLOBAL__username}"'" , "password": "'"${GLOBAL__password}"'" , "tfa": "'"${GLOBAL__tfa}"'" }' "${PARSEC_HOST}/v1/auth" | "${GLOBAL__jq}" --raw-output '.session_id' | {
 	while read LOCAL__line ; do
 		declare -g GLOBAL__session_id="${LOCAL__line}"
 	done
@@ -221,7 +221,7 @@ printf "Retrieve Session ID: "
 	printf "Retrieve Peer ID: "
 
 	# get peer ids.
-	/bin/curl --max-time 5 --silent --fail --request GET --header 'Content-Type: application/json' --header 'Authorization: Bearer '"${GLOBAL__session_id}"'' "${PARSEC_HOST}/v2/hosts?mode=desktop&public=false" | /bin/jq -r '.data[] | "\(.peer_id) (\(.name))"' | {
+	"${GLOBAL__curl}" --max-time 5 --silent --fail --request GET --header 'Content-Type: application/json' --header 'Authorization: Bearer '"${GLOBAL__session_id}"'' "${PARSEC_HOST}/v2/hosts?mode=desktop&public=false" | "${GLOBAL__jq}" -r '.data[] | "\(.peer_id) (\(.name))"' | {
 		while read LOCAL__line ; do
 
 			# store result.


### PR DESCRIPTION
## Summary

- Bump the project version to 0.3.1 and publish the release signing public key with release assets.
- Harden Parsec startup, reconnect, thread cleanup, DSO initialization, and audio polling synchronization.
- Fix input handling around Ctrl+Alt, Shift+F12, hidden cursor drags, and mouse coordinate restoration after reconnect.
- Fix CLI parsing, timeout overflow checks, USB redirect validation, and USB redirect cleanup paths.
- Refactor the Parsec event loop into focused helpers and resolve static-analysis/tooling issues.

## Commit Overview

- 692a571 - chore(release): bump version
- f839782 - ci: publish release signing key
- b5a6a70 - fix(input): pass Shift+F12 through unless no-grab is active
- e6b0c34 - fix(input): forward Ctrl+Alt when grab is disabled
- 5637e3f - fix(input): avoid cursor warp and flicker during hidden drags
- c89eafb - fix(usb): correct redirect port handling and bounds
- 6aa52d2 - fix(runtime): harden decoder startup and thread cleanup
- d5c7ddb - fix(usb): reject malformed redirect fields
- 7163b08 - fix(usb): clean up redirect device errors
- 00b5194 - fix(parsec): apply UPnP setting before SDK init
- c4549b5 - fix(cli): parse required option values from optarg
- 860aa08 - fix(usb): skip devices with unreadable descriptors
- 6d42e38 - fix(parsec): validate DSO init context
- 9617162 - fix(parsec): log reconnect failures
- 5dd3be3 - fix(parsec): serialize reconnect with audio polling
- b8797d5 - fix(cli): prevent timeout overflow
- 6dc3f0e - refactor(parsec): split event loop responsibilities
- 05b800c - fix(parsec): drop unused connection status result
- 6fd8e26 - fix(tools): resolve curl and jq from PATH
- a75c9c8 - fix(parsec): reset mouse dimensions on reconnect