### PR TITLE
Prepare v0.4.1 decoder and startup fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
             libusb-1.0-0-dev \
             libusbredirhost-dev \
             libusbredirparser-dev \
+            libva-dev \
             libvulkan-dev \
             libx11-dev \
             pkg-config \
@@ -208,6 +209,7 @@ jobs:
             libavutil-dev \
             libdrm-dev \
             libplacebo-dev \
+            libva-dev \
             libvulkan-dev \
             libx11-dev \
             pkg-config \

--- a/README.md
+++ b/README.md
@@ -106,9 +106,11 @@ The original SDK software and hardware decoder entries are disabled so all video
 decoding remains in the injected FFmpeg decoder.
 
 Any recent GPU with [VA-API](https://en.wikipedia.org/wiki/Video_Acceleration_API)
-support can be used for FFmpeg hardware decoding. If VA-API setup is not
-available, FFmpeg falls back to software decoding. The `--no-acceleration`
-option disables FFmpeg VA-API, so both codecs use FFmpeg software decoding.
+support can be used for FFmpeg hardware decoding. The client queries libva
+profile and decode-entrypoint metadata without encoding or decoding a test
+frame. It uses hardware H.265 when available, otherwise hardware H.264, and
+otherwise software H.264. The `--no-acceleration` option skips that query and
+uses software H.265, or software H.264 together with `--no-hevc`.
 With libplacebo and Vulkan, retained VA-API frames are imported as DRM PRIME
 DMA-BUFs and rendered without copying frame pixels through CPU memory.
 
@@ -170,9 +172,10 @@ descriptor for the main-thread renderer.
 The FFmpeg decoder tries VA-API first when hardware acceleration is enabled. It
 retains the decoded `AV_PIX_FMT_VAAPI` frame through the Parsec frame descriptor.
 Before connecting, the client queries the VA-API profiles and decode entrypoints
-on the same device FFmpeg will use. If H.264 VLD decoding is supported but no
-H.265 VLD profile is available, the client requests H.264 from the host
-immediately instead of attempting H.265 first.
+on the same device FFmpeg will use. This is a metadata-only query and does not
+encode or decode a test frame. If no H.265 VLD profile is available, the client
+requests H.264 from the host immediately. H.264 uses VA-API when its VLD profile
+is available and FFmpeg software decoding otherwise.
 The renderer maps that frame to DRM PRIME and derives each Vulkan plane format
 from the VA-API software layout before importing its DMA-BUF objects through
 libplacebo. This accommodates drivers such as `nvidia-vaapi-driver` whose
@@ -185,9 +188,10 @@ allocation bounds. If direct DMA-BUF import fails after Vulkan setup, the
 client transfers the frame to system memory and uploads it through libplacebo,
 avoiding SDL planar texture creation on the active Vulkan renderer. If Vulkan
 setup fails, the client recreates the window with the default SDL renderer. If
-VA-API is unavailable or initialization fails, the decoder falls back to
-FFmpeg software decoding. If the complete H.265 startup attempt fails, the
-client reconnects once with H.265 disabled and uses the FFmpeg H.264 decoder.
+VA-API initialization fails despite an advertised profile, that codec falls
+back to FFmpeg software decoding. If the complete H.265 startup attempt fails,
+the client reconnects once with H.265 disabled and uses the selected hardware
+or software FFmpeg H.264 decoder.
 
 Use `--no-hevc` to disable H.265 entirely and use the FFmpeg H.264 decoder. Use
 `--no-acceleration` to disable hardware decoding and use FFmpeg software decoding

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ descriptor for the main-thread renderer.
 
 The FFmpeg decoder tries VA-API first when hardware acceleration is enabled. It
 retains the decoded `AV_PIX_FMT_VAAPI` frame through the Parsec frame descriptor.
+Before connecting, the client queries the VA-API profiles and decode entrypoints
+on the same device FFmpeg will use. If H.264 VLD decoding is supported but no
+H.265 VLD profile is available, the client requests H.264 from the host
+immediately instead of attempting H.265 first.
 The renderer maps that frame to DRM PRIME and derives each Vulkan plane format
 from the VA-API software layout before importing its DMA-BUF objects through
 libplacebo. This accommodates drivers such as `nvidia-vaapi-driver` whose
@@ -230,7 +234,8 @@ applicable Parsec SDK terms allow you to do so.
 
 VDI Stream Client uses GNU Build System to configure, build and install the
 application. It requires `sdl3`, `sdl3-ttf`, `libusb`, `usbredir`,
-`libavcodec`, `libavutil`, `libavformat`, `libdrm`, `libplacebo`, Vulkan and the
+`libavcodec`, `libavutil`, `libavformat`, `libva`, `libdrm`, `libplacebo`,
+Vulkan and the
 [Parsec SDK](https://github.com/mbroemme/parsec-sdk). The original
 `parsec-cloud/parsec-sdk` repository is no longer available after Parsec was
 acquired by Unity, so this project references the mirrored SDK repository
@@ -253,7 +258,7 @@ On Debian or Ubuntu, install the build dependencies with:
 sudo apt install build-essential autoconf automake pkg-config \
   libsdl3-dev libsdl3-ttf-dev libusb-1.0-0-dev \
   libusbredirhost-dev libusbredirparser-dev \
-  libavcodec-dev libavformat-dev libavutil-dev libdrm-dev \
+  libavcodec-dev libavformat-dev libavutil-dev libva-dev libdrm-dev \
   libplacebo-dev libvulkan-dev
 ```
 
@@ -261,7 +266,7 @@ On Arch Linux, install the build dependencies with:
 
 ```
 sudo pacman -S base-devel autoconf automake pkgconf \
-  sdl3 sdl3_ttf libusb usbredir ffmpeg libdrm libplacebo vulkan-headers
+  sdl3 sdl3_ttf libusb usbredir ffmpeg libva libdrm libplacebo vulkan-headers
 ```
 
 For build and install use the commands below and if `--prefix=/usr` is used,

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # the autoconf initilization.
-AC_INIT(vdi-stream-client, 0.4.0, [mbroemme@libmpq.org], [vdi-stream-client])
+AC_INIT(vdi-stream-client, 0.4.1, [mbroemme@libmpq.org], [vdi-stream-client])
 
 # detect the canonical target environment.
 AC_CANONICAL_TARGET

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,9 @@ PKG_CHECK_MODULES([USBREDIRPARSER], [libusbredirparser-0.5 >= 0.7.1])
 # checking for FFmpeg decoder support.
 PKG_CHECK_MODULES([FFMPEG], [libavcodec >= 58 libavutil >= 56], [], [AC_MSG_ERROR([*** libavcodec >= 58 and libavutil >= 56 are required])])
 
+# checking for VA-API decoder capability support.
+PKG_CHECK_MODULES([VAAPI], [libva >= 1.7.0], [], [AC_MSG_ERROR([*** libva >= 1.7.0 is required])])
+
 # checking for libdrm format definitions.
 PKG_CHECK_MODULES([DRM], [libdrm], [], [AC_MSG_ERROR([*** libdrm is required])])
 

--- a/docs/man1/vdi-stream-client.1
+++ b/docs/man1/vdi-stream-client.1
@@ -98,8 +98,12 @@ Client options:
 .TP 8
 .B  \-\-no\-acceleration
 Disable hardware accelerated client decoding. If disabled, client will
-decode frames with FFmpeg in software on CPU. If enabled, client will
-use FFmpeg VA-API hardware decoding when available. VA-API frames are
+decode H.265 frames with FFmpeg in software on CPU, or H.264 when combined
+with
+.BR \-\-no\-hevc .
+If enabled, the client queries libva profile and decode-entrypoint metadata
+without processing a test frame. It uses VA-API H.265 when available, then
+VA-API H.264, then FFmpeg software H.264. VA-API frames are
 mapped to DRM PRIME and their modifier-aware DMA-BUF planes are imported
 through libplacebo into Vulkan without copying frame pixels through CPU
 memory. Older RADV devices without DRM modifier support use a validated

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,8 +3,8 @@ bin_PROGRAMS			= vdi-stream-client
 
 # sources for vdi-stream-client program.
 vdi_stream_client_SOURCES	= client.c parsec.c ffmpeg.c placebo.c redirect.c audio.c video.c input.c
-vdi_stream_client_CFLAGS	= $(USB_CFLAGS) $(USBREDIRHOST_CFLAGS) $(USBREDIRPARSER_CFLAGS) $(SDL3_CFLAGS) $(SDL3_TTF_CFLAGS) $(FFMPEG_CFLAGS) $(DRM_CFLAGS) $(PLACEBO_CFLAGS)
-vdi_stream_client_LDADD		= $(USB_LIBS) $(USBREDIRHOST_LIBS) $(USBREDIRPARSER_LIBS) $(SDL3_LIBS) $(SDL3_TTF_LIBS) $(FFMPEG_LIBS) $(PLACEBO_LIBS)
+vdi_stream_client_CFLAGS	= $(USB_CFLAGS) $(USBREDIRHOST_CFLAGS) $(USBREDIRPARSER_CFLAGS) $(SDL3_CFLAGS) $(SDL3_TTF_CFLAGS) $(FFMPEG_CFLAGS) $(VAAPI_CFLAGS) $(DRM_CFLAGS) $(PLACEBO_CFLAGS)
+vdi_stream_client_LDADD		= $(USB_LIBS) $(USBREDIRHOST_LIBS) $(USBREDIRPARSER_LIBS) $(SDL3_LIBS) $(SDL3_TTF_LIBS) $(FFMPEG_LIBS) $(VAAPI_LIBS) $(PLACEBO_LIBS)
 
 # install libparsec for dso loading. Redistribution requires Parsec SDK license permission.
 if INTERNAL_PARSEC_SDK

--- a/src/audio.c
+++ b/src/audio.c
@@ -35,6 +35,59 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+bool
+vdi_stream_client__audio_init(struct parsec_context_s *parsec_context, bool enabled)
+{
+    SDL_AudioSpec want = { 0 };
+    SDL_AudioDeviceID *devices;
+    int device_count = 0;
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Initialize Audio\n");
+    if (!enabled) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Disable audio streaming\n");
+        return true;
+    }
+
+    devices = SDL_GetAudioPlaybackDevices(&device_count);
+    if (devices == NULL) {
+        SDL_LogError(
+            SDL_LOG_CATEGORY_APPLICATION, "Failed to query audio devices: %s\n", SDL_GetError()
+        );
+        return false;
+    }
+    SDL_free(devices);
+
+    if (device_count == 0) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "No audio device available\n");
+        return true;
+    }
+
+    want.freq = PARSEC_AUDIO_SAMPLE_RATE;
+    want.format = SDL_AUDIO_S16;
+    want.channels = PARSEC_AUDIO_CHANNELS;
+
+    /* The number of audio packets to buffer before playback and overflow. */
+    parsec_context->min_buffer = 1;
+    parsec_context->max_buffer = 6;
+    parsec_context->audio =
+        SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &want, NULL, NULL);
+    if (parsec_context->audio == NULL) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to open audio: %s\n", SDL_GetError());
+        return false;
+    }
+
+    return true;
+}
+
+void
+vdi_stream_client__audio_destroy(struct parsec_context_s *parsec_context)
+{
+    if (parsec_context->audio != NULL) {
+        SDL_DestroyAudioStream(parsec_context->audio);
+        parsec_context->audio = NULL;
+    }
+}
+
 /* parsec audio event. */
 static void
 vdi_stream_client__audio(const Sint16 *pcm, Uint32 frames, void *opaque)

--- a/src/audio.h
+++ b/src/audio.h
@@ -26,6 +26,12 @@
 /* sdl includes. */
 #include <SDL3/SDL.h>
 
+struct parsec_context_s;
+
+/* audio device. */
+bool vdi_stream_client__audio_init(struct parsec_context_s *parsec_context, bool enabled);
+void vdi_stream_client__audio_destroy(struct parsec_context_s *parsec_context);
+
 /* audio thread. */
 Sint32 vdi_stream_client__audio_thread(void *opaque);
 

--- a/src/ffmpeg.c
+++ b/src/ffmpeg.c
@@ -102,6 +102,8 @@ static atomic_uint_fast64_t vdi_stream_client__parsec_ffmpeg_hwframe_transfer_ns
 static atomic_uint_fast64_t vdi_stream_client__parsec_ffmpeg_descriptor_fallback_calls;
 static atomic_uint_fast64_t vdi_stream_client__parsec_ffmpeg_descriptor_fallback_ns;
 static atomic_bool vdi_stream_client__parsec_ffmpeg_hardware_active;
+static atomic_bool vdi_stream_client__parsec_ffmpeg_h264_acceleration;
+static atomic_bool vdi_stream_client__parsec_ffmpeg_hevc_acceleration;
 
 static const char *vdi_stream_client__parsec_ffmpeg_error(Sint32 errnum, char *buffer, size_t len);
 
@@ -467,6 +469,7 @@ vdi_stream_client__parsec_ffmpeg_vaapi_codecs(bool *h264, bool *hevc)
     *h264 = false;
     *hevc = false;
 
+    /* Query profile metadata only. No VA config, context, surface or frame is created. */
     if (av_hwdevice_ctx_create(&device_ref, AV_HWDEVICE_TYPE_VAAPI, NULL, NULL, 0) < 0 ||
         device_ref == NULL) {
         goto cleanup;
@@ -796,13 +799,13 @@ vdi_stream_client__parsec_ffmpeg_free(struct vdi_stream_client__parsec_ffmpeg_de
 
 static Sint32
 vdi_stream_client__parsec_ffmpeg_init_common(
-    void *decoder, void *stream, Uint32 stream_id, void *codec_selector, void *flags,
-    bool acceleration
+    void *decoder, void *stream, Uint32 stream_id, void *codec_selector, void *flags
 )
 {
     struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg;
     const AVCodec *codec;
     Uint8 selector;
+    bool acceleration;
     Sint32 err;
     char errbuf[AV_ERROR_MAX_STRING_SIZE];
 
@@ -832,6 +835,11 @@ vdi_stream_client__parsec_ffmpeg_init_common(
 
     selector = codec_selector != NULL ? ((const Uint8 *)codec_selector)[0] : 2;
     ffmpeg->codec_id = selector == 2 ? AV_CODEC_ID_HEVC : AV_CODEC_ID_H264;
+    acceleration = atomic_load_explicit(
+        ffmpeg->codec_id == AV_CODEC_ID_HEVC ? &vdi_stream_client__parsec_ffmpeg_hevc_acceleration
+                                             : &vdi_stream_client__parsec_ffmpeg_h264_acceleration,
+        memory_order_relaxed
+    );
 
     codec = avcodec_find_decoder(ffmpeg->codec_id);
     if (codec == NULL) {
@@ -899,17 +907,7 @@ vdi_stream_client__parsec_ffmpeg_init(
 )
 {
     return vdi_stream_client__parsec_ffmpeg_init_common(
-        decoder, stream, stream_id, codec_selector, flags, true
-    );
-}
-
-static Sint32
-vdi_stream_client__parsec_ffmpeg_init_no_acceleration(
-    void *decoder, void *stream, Uint32 stream_id, void *codec_selector, void *flags
-)
-{
-    return vdi_stream_client__parsec_ffmpeg_init_common(
-        decoder, stream, stream_id, codec_selector, flags, false
+        decoder, stream, stream_id, codec_selector, flags
     );
 }
 
@@ -1322,7 +1320,8 @@ vdi_stream_client__parsec_ffmpeg_decode(
 
 bool
 vdi_stream_client__parsec_ffmpeg_decoder_enable(
-    struct parsec_context_s *parsec_context, Uint32 *decoder_index, bool acceleration
+    struct parsec_context_s *parsec_context, Uint32 *decoder_index, bool h264_acceleration,
+    bool hevc_acceleration
 )
 {
     Uint8 *table;
@@ -1334,6 +1333,12 @@ vdi_stream_client__parsec_ffmpeg_decoder_enable(
     );
     atomic_store_explicit(
         &vdi_stream_client__parsec_ffmpeg_hardware_active, false, memory_order_release
+    );
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_h264_acceleration, h264_acceleration, memory_order_relaxed
+    );
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_hevc_acceleration, hevc_acceleration, memory_order_relaxed
     );
 
     table = vdi_stream_client__parsec_decoder_table(parsec_context);
@@ -1364,8 +1369,7 @@ vdi_stream_client__parsec_ffmpeg_decoder_enable(
     }
 
     ((uintptr_t *)(void *)(entry + VDI_STREAM_CLIENT_PARSEC_DECODER_INIT_OFFSET))[0] =
-        acceleration ? (uintptr_t)(void *)vdi_stream_client__parsec_ffmpeg_init
-                     : (uintptr_t)(void *)vdi_stream_client__parsec_ffmpeg_init_no_acceleration;
+        (uintptr_t)(void *)vdi_stream_client__parsec_ffmpeg_init;
     ((uintptr_t *)(void *)(entry + VDI_STREAM_CLIENT_PARSEC_DECODER_DECODE_OFFSET))[0] =
         (uintptr_t)(void *)vdi_stream_client__parsec_ffmpeg_decode;
     ((uintptr_t *)(void *)(entry + VDI_STREAM_CLIENT_PARSEC_DECODER_CLEANUP_OFFSET))[0] =

--- a/src/ffmpeg.c
+++ b/src/ffmpeg.c
@@ -19,6 +19,7 @@
 #include <libavutil/avutil.h>
 #include <libavutil/frame.h>
 #include <libavutil/hwcontext.h>
+#include <libavutil/hwcontext_vaapi.h>
 #include <libavutil/pixfmt.h>
 #include <limits.h>
 #include <stdatomic.h>
@@ -26,6 +27,10 @@
 #include <stdio.h>
 #include <sys/mman.h>
 #include <unistd.h>
+
+/* va-api includes. */
+#include <va/va.h>
+#include <va/va_str.h>
 
 #if !defined(__linux__)
 #error "The FFmpeg Parsec decoder integration currently supports Linux only."
@@ -421,6 +426,98 @@ vdi_stream_client__parsec_ffmpeg_decoder_is_hardware(void)
     return atomic_load_explicit(
         &vdi_stream_client__parsec_ffmpeg_hardware_active, memory_order_acquire
     );
+}
+
+static bool
+vdi_stream_client__parsec_ffmpeg_vaapi_profile_decode(
+    VADisplay display, VAProfile profile, VAEntrypoint *entrypoints, Sint32 max_entrypoints
+)
+{
+    Sint32 entrypoint_count = max_entrypoints;
+
+    if (vaQueryConfigEntrypoints(display, profile, entrypoints, &entrypoint_count) !=
+        VA_STATUS_SUCCESS) {
+        return false;
+    }
+    for (Sint32 i = 0; i < entrypoint_count; i++) {
+        if (entrypoints[i] == VAEntrypointVLD) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool
+vdi_stream_client__parsec_ffmpeg_vaapi_codecs(bool *h264, bool *hevc)
+{
+    AVBufferRef *device_ref = NULL;
+    AVHWDeviceContext *device_context;
+    AVVAAPIDeviceContext *vaapi_context;
+    VAEntrypoint *entrypoints = NULL;
+    VAProfile *profiles = NULL;
+    VADisplay display;
+    Sint32 max_entrypoints;
+    Sint32 max_profiles;
+    Sint32 profile_count;
+    bool available = false;
+
+    if (h264 == NULL || hevc == NULL) {
+        return false;
+    }
+    *h264 = false;
+    *hevc = false;
+
+    if (av_hwdevice_ctx_create(&device_ref, AV_HWDEVICE_TYPE_VAAPI, NULL, NULL, 0) < 0 ||
+        device_ref == NULL) {
+        goto cleanup;
+    }
+    device_context = (AVHWDeviceContext *)device_ref->data;
+    vaapi_context = device_context != NULL ? device_context->hwctx : NULL;
+    display = vaapi_context != NULL ? vaapi_context->display : NULL;
+    if (display == NULL) {
+        goto cleanup;
+    }
+
+    max_profiles = vaMaxNumProfiles(display);
+    max_entrypoints = vaMaxNumEntrypoints(display);
+    if (max_profiles <= 0 || max_entrypoints <= 0) {
+        goto cleanup;
+    }
+    profiles = SDL_malloc((size_t)max_profiles * sizeof(*profiles));
+    entrypoints = SDL_malloc((size_t)max_entrypoints * sizeof(*entrypoints));
+    if (profiles == NULL || entrypoints == NULL) {
+        goto cleanup;
+    }
+
+    profile_count = max_profiles;
+    if (vaQueryConfigProfiles(display, profiles, &profile_count) != VA_STATUS_SUCCESS) {
+        goto cleanup;
+    }
+    available = true;
+    for (Sint32 i = 0; i < profile_count; i++) {
+        const char *name;
+
+        if (!vdi_stream_client__parsec_ffmpeg_vaapi_profile_decode(
+                display, profiles[i], entrypoints, max_entrypoints
+            )) {
+            continue;
+        }
+        name = vaProfileStr(profiles[i]);
+        if (name == NULL) {
+            continue;
+        }
+        if (SDL_strncmp(name, "VAProfileH264", sizeof("VAProfileH264") - 1) == 0) {
+            *h264 = true;
+        } else if (SDL_strncmp(name, "VAProfileHEVC", sizeof("VAProfileHEVC") - 1) == 0) {
+            *hevc = true;
+        }
+    }
+
+cleanup:
+    SDL_free(entrypoints);
+    SDL_free(profiles);
+    av_buffer_unref(&device_ref);
+    return available;
 }
 
 static bool

--- a/src/ffmpeg.h
+++ b/src/ffmpeg.h
@@ -52,6 +52,7 @@ void vdi_stream_client__parsec_ffmpeg_drain_stats(
     struct vdi_stream_client__parsec_ffmpeg_stats_s *stats
 );
 bool vdi_stream_client__parsec_ffmpeg_decoder_is_hardware(void);
+bool vdi_stream_client__parsec_ffmpeg_vaapi_codecs(bool *h264, bool *hevc);
 
 bool vdi_stream_client__parsec_ffmpeg_decoder_enable(
     struct parsec_context_s *parsec_context, Uint32 *decoder_index, bool acceleration

--- a/src/ffmpeg.h
+++ b/src/ffmpeg.h
@@ -55,7 +55,8 @@ bool vdi_stream_client__parsec_ffmpeg_decoder_is_hardware(void);
 bool vdi_stream_client__parsec_ffmpeg_vaapi_codecs(bool *h264, bool *hevc);
 
 bool vdi_stream_client__parsec_ffmpeg_decoder_enable(
-    struct parsec_context_s *parsec_context, Uint32 *decoder_index, bool acceleration
+    struct parsec_context_s *parsec_context, Uint32 *decoder_index, bool h264_acceleration,
+    bool hevc_acceleration
 );
 
 #endif /* _FFMPEG_H */

--- a/src/input.c
+++ b/src/input.c
@@ -65,6 +65,7 @@ vdi_stream_client__input_init(
         return false;
     }
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Initialize Input\n");
     SDL_memset(input_context, 0, sizeof(*input_context));
     input_context->parsec_context = parsec_context;
     input_context->vdi_config = vdi_config;

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -921,10 +921,6 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     }
     cfg.video[DEFAULT_STREAM].decoderIndex = ffmpeg_decoder_index;
     hevc_attempt_active = vdi_config->hevc == 1;
-    SDL_LogInfo(
-        SDL_LOG_CATEGORY_APPLICATION, "Use FFmpeg Video Decoder for %s\n",
-        vdi_config->hevc == 1 ? "H.265 (HEVC)" : "H.264 (AVC)"
-    );
 
     /* check if reconnect should be disabled. */
     if (vdi_config->reconnect == 0) {

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -910,6 +910,19 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     if (vdi_config->acceleration == 0) {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Disable Hardware Accelerated Video Decoding\n");
     }
+    if (vdi_config->acceleration == 1 && cfg.video[DEFAULT_STREAM].decoderH265 == 1) {
+        bool h264 = false;
+        bool hevc = false;
+
+        if (vdi_stream_client__parsec_ffmpeg_vaapi_codecs(&h264, &hevc) && h264 && !hevc) {
+            SDL_LogInfo(
+                SDL_LOG_CATEGORY_APPLICATION,
+                "VA-API H.265 decoding unsupported, use H.264 (AVC) hardware fallback\n"
+            );
+            cfg.video[DEFAULT_STREAM].decoderH265 = 0;
+        }
+    }
+
     /* Configure client-side FFmpeg for H.264 and H.265. The public Linux SDK
      * exposes a hidden FFmpeg decoder entry; replace that entry with the client
      * decoder so both codecs use the same owned VAAPI or software path. */
@@ -920,7 +933,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
         goto error;
     }
     cfg.video[DEFAULT_STREAM].decoderIndex = ffmpeg_decoder_index;
-    hevc_attempt_active = vdi_config->hevc == 1;
+    hevc_attempt_active = cfg.video[DEFAULT_STREAM].decoderH265 == 1;
 
     /* check if reconnect should be disabled. */
     if (vdi_config->reconnect == 0) {

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -807,9 +807,6 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     Uint32 wait_time = 0;
     Uint64 last_time = 0;
     bool force_redraw = false;
-    SDL_AudioSpec want = { 0 };
-    SDL_AudioDeviceID *audio_devices = NULL;
-    Sint32 audio_device_count = 0;
     ParsecStatus e;
     ParsecConfig network_cfg = PARSEC_DEFAULTS;
     ParsecClientConfig cfg = PARSEC_CLIENT_DEFAULTS;
@@ -872,6 +869,8 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Initialization failed with code: %d\n", e);
         goto error;
     }
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Initialize Video\n");
 
     /* use client resolution if specified. */
     if (vdi_config->width > 0 && vdi_config->height > 0) {
@@ -938,6 +937,14 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     cfg.video[DEFAULT_STREAM].decoderIndex = ffmpeg_decoder_index;
     hevc_attempt_active = cfg.video[DEFAULT_STREAM].decoderH265 == 1;
 
+    if (!vdi_stream_client__audio_init(&parsec_context, vdi_config->audio == 1)) {
+        goto error;
+    }
+
+    if (!vdi_stream_client__input_init(&input_context, &parsec_context, vdi_config)) {
+        goto error;
+    }
+
     /* check if reconnect should be disabled. */
     if (vdi_config->reconnect == 0) {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Disable automatic reconnect\n");
@@ -966,11 +973,6 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     /* check if clipboard should be disabled. */
     if (vdi_config->clipboard == 0) {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Disable clipboard sharing\n");
-    }
-
-    /* check if audio should be streamed. */
-    if (vdi_config->audio == 0) {
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Disable audio streaming\n");
     }
 
     for (;;) {
@@ -1084,52 +1086,16 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
         }
     }
 
-    /* check if audio should be streamed. */
-    if (vdi_config->audio == 1) {
-        audio_devices = SDL_GetAudioPlaybackDevices(&audio_device_count);
-        if (audio_devices == NULL) {
+    /* start polling audio only after the connection and video output are ready. */
+    if (parsec_context.audio != NULL) {
+        audio_thread = SDL_CreateThread(
+            vdi_stream_client__audio_thread, "vdi_stream_client__audio_thread", &parsec_context
+        );
+        if (audio_thread == NULL) {
             SDL_LogError(
-                SDL_LOG_CATEGORY_APPLICATION, "Failed to query audio devices: %s\n", SDL_GetError()
+                SDL_LOG_CATEGORY_APPLICATION, "Audio thread creation failed: %s\n", SDL_GetError()
             );
             goto error;
-        }
-        SDL_free(audio_devices);
-        audio_devices = NULL;
-
-        if (audio_device_count == 0) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "No audio device available\n");
-        } else {
-            want.freq = PARSEC_AUDIO_SAMPLE_RATE;
-            want.format = SDL_AUDIO_S16;
-            want.channels = PARSEC_AUDIO_CHANNELS;
-
-            /* the number of audio packets (960 frames) to buffer before we begin playing. */
-            parsec_context.min_buffer = 1;
-
-            /* the number of audio packets (960 frames) to buffer before overflow and clear. */
-            parsec_context.max_buffer = 6;
-
-            /* sdl audio device. */
-            parsec_context.audio =
-                SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &want, NULL, NULL);
-            if (parsec_context.audio == NULL) {
-                SDL_LogError(
-                    SDL_LOG_CATEGORY_APPLICATION, "Failed to open audio: %s\n", SDL_GetError()
-                );
-                goto error;
-            }
-
-            /* sdl audio thread. */
-            audio_thread = SDL_CreateThread(
-                vdi_stream_client__audio_thread, "vdi_stream_client__audio_thread", &parsec_context
-            );
-            if (audio_thread == NULL) {
-                SDL_LogError(
-                    SDL_LOG_CATEGORY_APPLICATION, "Audio thread creation failed: %s\n",
-                    SDL_GetError()
-                );
-                goto error;
-            }
         }
     }
 
@@ -1164,11 +1130,8 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
         }
     }
 
-    /* sdl input thread. SDL events are pumped on the main thread and handled
-     * by this worker without running main-thread-only window APIs there. */
-    if (!vdi_stream_client__input_init(&input_context, &parsec_context, vdi_config)) {
-        goto error;
-    }
+    /* SDL events are pumped on the main thread and handled by this worker
+     * without running main-thread-only window APIs there. */
     input_thread = SDL_CreateThread(
         vdi_stream_client__input_thread, "vdi_stream_client__input_thread", &input_context
     );
@@ -1310,9 +1273,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     TTF_Quit();
 
     /* sdl destroy. */
-    if (parsec_context.audio != NULL) {
-        SDL_DestroyAudioStream(parsec_context.audio);
-    }
+    vdi_stream_client__audio_destroy(&parsec_context);
     SDL_DestroySurface(parsec_context.surface_ttf);
     SDL_DestroyWindow(parsec_context.window);
     SDL_Quit();
@@ -1338,9 +1299,7 @@ error:
     TTF_Quit();
 
     /* sdl destroy. */
-    if (parsec_context.audio != NULL) {
-        SDL_DestroyAudioStream(parsec_context.audio);
-    }
+    vdi_stream_client__audio_destroy(&parsec_context);
     SDL_DestroySurface(parsec_context.surface_ttf);
     SDL_DestroyWindow(parsec_context.window);
     SDL_Quit();

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -808,6 +808,8 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     Uint64 last_time = 0;
     bool force_redraw = false;
     SDL_AudioSpec want = { 0 };
+    SDL_AudioDeviceID *audio_devices = NULL;
+    Sint32 audio_device_count = 0;
     ParsecStatus e;
     ParsecConfig network_cfg = PARSEC_DEFAULTS;
     ParsecClientConfig cfg = PARSEC_CLIENT_DEFAULTS;
@@ -1084,35 +1086,50 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
 
     /* check if audio should be streamed. */
     if (vdi_config->audio == 1) {
-        want.freq = PARSEC_AUDIO_SAMPLE_RATE;
-        want.format = SDL_AUDIO_S16;
-        want.channels = PARSEC_AUDIO_CHANNELS;
-
-        /* the number of audio packets (960 frames) to buffer before we begin playing. */
-        parsec_context.min_buffer = 1;
-
-        /* the number of audio packets (960 frames) to buffer before overflow and clear. */
-        parsec_context.max_buffer = 6;
-
-        /* sdl audio device. */
-        parsec_context.audio =
-            SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &want, NULL, NULL);
-        if (parsec_context.audio == NULL) {
+        audio_devices = SDL_GetAudioPlaybackDevices(&audio_device_count);
+        if (audio_devices == NULL) {
             SDL_LogError(
-                SDL_LOG_CATEGORY_APPLICATION, "Failed to open audio: %s\n", SDL_GetError()
+                SDL_LOG_CATEGORY_APPLICATION, "Failed to query audio devices: %s\n", SDL_GetError()
             );
             goto error;
         }
+        SDL_free(audio_devices);
+        audio_devices = NULL;
 
-        /* sdl audio thread. */
-        audio_thread = SDL_CreateThread(
-            vdi_stream_client__audio_thread, "vdi_stream_client__audio_thread", &parsec_context
-        );
-        if (audio_thread == NULL) {
-            SDL_LogError(
-                SDL_LOG_CATEGORY_APPLICATION, "Audio thread creation failed: %s\n", SDL_GetError()
+        if (audio_device_count == 0) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "No audio device available\n");
+        } else {
+            want.freq = PARSEC_AUDIO_SAMPLE_RATE;
+            want.format = SDL_AUDIO_S16;
+            want.channels = PARSEC_AUDIO_CHANNELS;
+
+            /* the number of audio packets (960 frames) to buffer before we begin playing. */
+            parsec_context.min_buffer = 1;
+
+            /* the number of audio packets (960 frames) to buffer before overflow and clear. */
+            parsec_context.max_buffer = 6;
+
+            /* sdl audio device. */
+            parsec_context.audio =
+                SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &want, NULL, NULL);
+            if (parsec_context.audio == NULL) {
+                SDL_LogError(
+                    SDL_LOG_CATEGORY_APPLICATION, "Failed to open audio: %s\n", SDL_GetError()
+                );
+                goto error;
+            }
+
+            /* sdl audio thread. */
+            audio_thread = SDL_CreateThread(
+                vdi_stream_client__audio_thread, "vdi_stream_client__audio_thread", &parsec_context
             );
-            goto error;
+            if (audio_thread == NULL) {
+                SDL_LogError(
+                    SDL_LOG_CATEGORY_APPLICATION, "Audio thread creation failed: %s\n",
+                    SDL_GetError()
+                );
+                goto error;
+            }
         }
     }
 
@@ -1293,7 +1310,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     TTF_Quit();
 
     /* sdl destroy. */
-    if (vdi_config->audio == 1) {
+    if (parsec_context.audio != NULL) {
         SDL_DestroyAudioStream(parsec_context.audio);
     }
     SDL_DestroySurface(parsec_context.surface_ttf);
@@ -1321,7 +1338,7 @@ error:
     TTF_Quit();
 
     /* sdl destroy. */
-    if (vdi_config->audio == 1) {
+    if (parsec_context.audio != NULL) {
         SDL_DestroyAudioStream(parsec_context.audio);
     }
     SDL_DestroySurface(parsec_context.surface_ttf);

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -814,6 +814,8 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     Uint32 ffmpeg_decoder_index = UINT32_MAX;
     bool hevc_attempt_active = false;
     bool h264_fallback_done = false;
+    bool h264_acceleration = false;
+    bool hevc_acceleration = false;
     bool hardware_decoding;
     Uint32 device;
     SDL_Thread *input_thread = NULL;
@@ -910,14 +912,13 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     if (vdi_config->acceleration == 0) {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Disable Hardware Accelerated Video Decoding\n");
     }
-    if (vdi_config->acceleration == 1 && cfg.video[DEFAULT_STREAM].decoderH265 == 1) {
-        bool h264 = false;
-        bool hevc = false;
-
-        if (vdi_stream_client__parsec_ffmpeg_vaapi_codecs(&h264, &hevc) && h264 && !hevc) {
-            SDL_LogInfo(
-                SDL_LOG_CATEGORY_APPLICATION,
-                "VA-API H.265 decoding unsupported, use H.264 (AVC) hardware fallback\n"
+    if (vdi_config->acceleration == 1) {
+        (void)vdi_stream_client__parsec_ffmpeg_vaapi_codecs(&h264_acceleration, &hevc_acceleration);
+        if (cfg.video[DEFAULT_STREAM].decoderH265 == 1 && !hevc_acceleration) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "VA-API H.265 decoding unavailable\n");
+            SDL_LogWarn(
+                SDL_LOG_CATEGORY_APPLICATION, "Use H.264 (AVC) %s fallback\n",
+                h264_acceleration ? "hardware" : "software"
             );
             cfg.video[DEFAULT_STREAM].decoderH265 = 0;
         }
@@ -927,7 +928,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
      * exposes a hidden FFmpeg decoder entry; replace that entry with the client
      * decoder so both codecs use the same owned VAAPI or software path. */
     if (!vdi_stream_client__parsec_ffmpeg_decoder_enable(
-            &parsec_context, &ffmpeg_decoder_index, vdi_config->acceleration == 1
+            &parsec_context, &ffmpeg_decoder_index, h264_acceleration, hevc_acceleration
         )) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "FFmpeg decoder injection failed\n");
         goto error;


### PR DESCRIPTION
## Summary

* Bump the project version to 0.4.1 for the next release.
* Remove a redundant FFmpeg decoder log from the Parsec event loop.
* Detect VA-API HEVC support before connecting and fall back to H.264 when HEVC VLD decoding is unavailable.
* Select the decoder from VA-API capabilities without processing test frames, preserving explicit software HEVC and AVC modes.
* Add libva as an explicit build and CI dependency and document the VA-API capability selection behavior.
* Continue startup when no playback device is available instead of failing the whole client initialization.
* Refactor client startup into explicit video, audio, and input initialization phases before connecting to Parsec.
* Defer audio and input worker thread startup until video setup has completed successfully.

## Commit Overview

* 0a1fdc2 - chore(release): bump version
* 9db0201 - fix(video): remove redundant FFmpeg decoder log
* bca3b9a - fix(video): detect VA-API HEVC support before connecting
* fa7e42e - fix(video): select decoder from VA-API capabilities
* 46ac739 - fix(audio): continue when no playback device is available
* e351895 - refactor(client): initialize subsystems before connecting