### PR TITLE
Prepare v0.5.1 VA-API reconnect and resize fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # the autoconf initilization.
-AC_INIT(vdi-stream-client, 0.5.0, [mbroemme@libmpq.org], [vdi-stream-client])
+AC_INIT(vdi-stream-client, 0.5.1, [mbroemme@libmpq.org], [vdi-stream-client])
 
 # detect the canonical target environment.
 AC_CANONICAL_TARGET

--- a/src/ffmpeg.c
+++ b/src/ffmpeg.c
@@ -107,7 +107,40 @@ static atomic_bool vdi_stream_client__parsec_ffmpeg_h264_acceleration;
 static atomic_bool vdi_stream_client__parsec_ffmpeg_hevc_acceleration;
 static atomic_bool vdi_stream_client__parsec_ffmpeg_color444;
 
+/* The injected decoder is created once and reused for the lifetime of the
+ * process. The Parsec SDK tears the decoder down and recreates it on every
+ * reconnect, but building a fresh VA-API/UVD decode context on the long-lived
+ * shared amdgpu device makes the kernel reject that context's first decode
+ * submission with -ENOMEM and aborts (the context created on the first connect,
+ * while the device was fresh, keeps working). Keeping one decode context across
+ * reconnects avoids creating a new one. */
+static SDL_Mutex *vdi_stream_client__parsec_ffmpeg_decoder_lock;
+static struct vdi_stream_client__parsec_ffmpeg_decoder_s
+    *vdi_stream_client__parsec_ffmpeg_decoder_cache;
+
 static const char *vdi_stream_client__parsec_ffmpeg_error(Sint32 errnum, char *buffer, size_t len);
+static void
+vdi_stream_client__parsec_ffmpeg_free(struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg);
+
+/* Release every retained frame slot so a reused decoder does not keep the
+ * previous stream's hardware surfaces referenced after a reconnect. */
+static void
+vdi_stream_client__parsec_ffmpeg_reset_frames(
+    struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg
+)
+{
+    if (ffmpeg == NULL || ffmpeg->frame_lock == NULL) {
+        return;
+    }
+    SDL_LockMutex(ffmpeg->frame_lock);
+    for (Uint32 i = 0; i < VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_SLOTS; i++) {
+        av_frame_free(&ffmpeg->frame_slots[i].frame);
+        ffmpeg->frame_slots[i].generation = 0;
+    }
+    ffmpeg->frame_generation = 0;
+    ffmpeg->frame_slot = 0;
+    SDL_UnlockMutex(ffmpeg->frame_lock);
+}
 
 /* Return the CPU-visible pixel format for an AVFrame. VA-API frames expose this
  * through their hardware frames context, while software frames store it directly
@@ -993,6 +1026,7 @@ vdi_stream_client__parsec_ffmpeg_init_common(
     struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg;
     const AVCodec *codec;
     Uint8 selector;
+    enum AVCodecID requested_codec_id;
     bool acceleration;
     Sint32 err;
     char errbuf[AV_ERROR_MAX_STRING_SIZE];
@@ -1003,6 +1037,37 @@ vdi_stream_client__parsec_ffmpeg_init_common(
 
     if (decoder == NULL) {
         return DECODE_ERR_INIT;
+    }
+
+    selector = codec_selector != NULL ? ((const Uint8 *)codec_selector)[0] : 2;
+    requested_codec_id = selector == 2 ? AV_CODEC_ID_HEVC : AV_CODEC_ID_H264;
+
+    /* Reuse the decode context built on a previous connect when its codec still
+     * matches. This keeps the proven VA-API/UVD context alive across reconnects
+     * instead of creating a new one on the aged shared amdgpu device. */
+    if (vdi_stream_client__parsec_ffmpeg_decoder_lock != NULL) {
+        SDL_LockMutex(vdi_stream_client__parsec_ffmpeg_decoder_lock);
+        ffmpeg = vdi_stream_client__parsec_ffmpeg_decoder_cache;
+        if (ffmpeg != NULL && ffmpeg->codec_id == requested_codec_id) {
+            SDL_UnlockMutex(vdi_stream_client__parsec_ffmpeg_decoder_lock);
+            vdi_stream_client__parsec_ffmpeg_reset_frames(ffmpeg);
+            if (ffmpeg->codec != NULL) {
+                avcodec_flush_buffers(ffmpeg->codec);
+            }
+            *((void **)decoder) = ffmpeg;
+            atomic_store_explicit(
+                &vdi_stream_client__parsec_ffmpeg_hardware_active, ffmpeg->hwaccel,
+                memory_order_release
+            );
+            return PARSEC_OK;
+        }
+
+        /* A cached decoder for a different codec cannot be reused. */
+        if (ffmpeg != NULL) {
+            vdi_stream_client__parsec_ffmpeg_free(ffmpeg);
+            vdi_stream_client__parsec_ffmpeg_decoder_cache = NULL;
+        }
+        SDL_UnlockMutex(vdi_stream_client__parsec_ffmpeg_decoder_lock);
     }
 
     ffmpeg = SDL_calloc(1, sizeof(*ffmpeg));
@@ -1021,8 +1086,7 @@ vdi_stream_client__parsec_ffmpeg_init_common(
         ffmpeg->frame_slots[i].lock = ffmpeg->frame_lock;
     }
 
-    selector = codec_selector != NULL ? ((const Uint8 *)codec_selector)[0] : 2;
-    ffmpeg->codec_id = selector == 2 ? AV_CODEC_ID_HEVC : AV_CODEC_ID_H264;
+    ffmpeg->codec_id = requested_codec_id;
     acceleration = atomic_load_explicit(
         ffmpeg->codec_id == AV_CODEC_ID_HEVC ? &vdi_stream_client__parsec_ffmpeg_hevc_acceleration
                                              : &vdi_stream_client__parsec_ffmpeg_h264_acceleration,
@@ -1086,6 +1150,13 @@ vdi_stream_client__parsec_ffmpeg_init_common(
         &vdi_stream_client__parsec_ffmpeg_hardware_active, ffmpeg->hwaccel, memory_order_release
     );
     ffmpeg->mode_published = true;
+
+    /* Retain the freshly built decoder so later reconnects reuse it. */
+    if (vdi_stream_client__parsec_ffmpeg_decoder_lock != NULL) {
+        SDL_LockMutex(vdi_stream_client__parsec_ffmpeg_decoder_lock);
+        vdi_stream_client__parsec_ffmpeg_decoder_cache = ffmpeg;
+        SDL_UnlockMutex(vdi_stream_client__parsec_ffmpeg_decoder_lock);
+    }
     return PARSEC_OK;
 }
 
@@ -1117,8 +1188,38 @@ vdi_stream_client__parsec_ffmpeg_cleanup(void *decoder)
         return;
     }
 
+    /* Keep the cached decoder alive so the next reconnect reuses its decode
+     * context; only detach it from the SDK slot. Non-cached instances (for
+     * example when the cache lock is unavailable) are freed normally. */
+    if (vdi_stream_client__parsec_ffmpeg_decoder_lock != NULL) {
+        SDL_LockMutex(vdi_stream_client__parsec_ffmpeg_decoder_lock);
+        if (ffmpeg == vdi_stream_client__parsec_ffmpeg_decoder_cache) {
+            SDL_UnlockMutex(vdi_stream_client__parsec_ffmpeg_decoder_lock);
+            *((void **)decoder) = NULL;
+            return;
+        }
+        SDL_UnlockMutex(vdi_stream_client__parsec_ffmpeg_decoder_lock);
+    }
+
     vdi_stream_client__parsec_ffmpeg_free(ffmpeg);
     *((void **)decoder) = NULL;
+}
+
+/* Free the reused decode context and its cache lock once the Parsec client and
+ * all decoder slots have been torn down. Safe to call when nothing was cached. */
+void
+vdi_stream_client__parsec_ffmpeg_decoder_destroy(void)
+{
+    if (vdi_stream_client__parsec_ffmpeg_decoder_lock != NULL) {
+        SDL_LockMutex(vdi_stream_client__parsec_ffmpeg_decoder_lock);
+        if (vdi_stream_client__parsec_ffmpeg_decoder_cache != NULL) {
+            vdi_stream_client__parsec_ffmpeg_free(vdi_stream_client__parsec_ffmpeg_decoder_cache);
+            vdi_stream_client__parsec_ffmpeg_decoder_cache = NULL;
+        }
+        SDL_UnlockMutex(vdi_stream_client__parsec_ffmpeg_decoder_lock);
+        SDL_DestroyMutex(vdi_stream_client__parsec_ffmpeg_decoder_lock);
+        vdi_stream_client__parsec_ffmpeg_decoder_lock = NULL;
+    }
 }
 
 /* Copy one AVFrame plane into a tightly packed destination plane, honoring the
@@ -1566,6 +1667,10 @@ vdi_stream_client__parsec_ffmpeg_decoder_enable(
     atomic_store_explicit(
         &vdi_stream_client__parsec_ffmpeg_color444, color444, memory_order_relaxed
     );
+
+    if (vdi_stream_client__parsec_ffmpeg_decoder_lock == NULL) {
+        vdi_stream_client__parsec_ffmpeg_decoder_lock = SDL_CreateMutex();
+    }
 
     table = vdi_stream_client__parsec_decoder_table(parsec_context);
     if (table == NULL) {

--- a/src/ffmpeg.c
+++ b/src/ffmpeg.c
@@ -90,6 +90,8 @@ struct vdi_stream_client__parsec_ffmpeg_decoder_s
     bool manual_hw_frames;
     bool mode_published;
     bool format_configured;
+    int configured_width;
+    int configured_height;
     int configured_coded_width;
     int configured_coded_height;
     SDL_Mutex *frame_lock;
@@ -1032,14 +1034,20 @@ vdi_stream_client__parsec_ffmpeg_first_software_format(const enum AVPixelFormat 
 
 static enum AVPixelFormat
 vdi_stream_client__parsec_ffmpeg_raise_resolution_reset(
-    AVCodecContext *codec, const enum AVPixelFormat *formats
+    AVCodecContext *codec, const enum AVPixelFormat *formats, int target_width, int target_height
 )
 {
+    if (target_width <= 0) {
+        target_width = codec->width;
+    }
+    if (target_height <= 0) {
+        target_height = codec->height;
+    }
     atomic_store_explicit(
-        &vdi_stream_client__parsec_ffmpeg_target_width, codec->width, memory_order_relaxed
+        &vdi_stream_client__parsec_ffmpeg_target_width, target_width, memory_order_relaxed
     );
     atomic_store_explicit(
-        &vdi_stream_client__parsec_ffmpeg_target_height, codec->height, memory_order_relaxed
+        &vdi_stream_client__parsec_ffmpeg_target_height, target_height, memory_order_relaxed
     );
     atomic_store_explicit(
         &vdi_stream_client__parsec_ffmpeg_aborting_decode, true, memory_order_release
@@ -1069,6 +1077,115 @@ vdi_stream_client__parsec_ffmpeg_coded_size(AVCodecContext *codec, int *width, i
     *width = coded_width;
     *height = coded_height;
     return true;
+}
+
+static bool
+vdi_stream_client__parsec_ffmpeg_vaapi_profile_matches_codec(
+    enum AVCodecID codec_id, const char *profile_name
+)
+{
+    if (profile_name == NULL) {
+        return false;
+    }
+    switch (codec_id) {
+    case AV_CODEC_ID_H264:
+        return SDL_strncmp(profile_name, "VAProfileH264", sizeof("VAProfileH264") - 1) == 0;
+    case AV_CODEC_ID_HEVC:
+        return SDL_strncmp(profile_name, "VAProfileHEVC", sizeof("VAProfileHEVC") - 1) == 0;
+    default:
+        return false;
+    }
+}
+
+static bool
+vdi_stream_client__parsec_ffmpeg_vaapi_size_supported(
+    AVBufferRef *device_ref, enum AVCodecID codec_id, int coded_width, int coded_height
+)
+{
+    AVHWDeviceContext *device_context;
+    AVVAAPIDeviceContext *vaapi_context;
+    VAEntrypoint *entrypoints = NULL;
+    VAProfile *profiles = NULL;
+    VADisplay display;
+    Sint32 max_entrypoints;
+    Sint32 max_profiles;
+    Sint32 profile_count;
+    bool supported = false;
+    bool found_limits = false;
+
+    if (device_ref == NULL || device_ref->data == NULL || coded_width <= 0 || coded_height <= 0) {
+        return true;
+    }
+
+    device_context = (AVHWDeviceContext *)device_ref->data;
+    vaapi_context = device_context != NULL ? device_context->hwctx : NULL;
+    display = vaapi_context != NULL ? vaapi_context->display : NULL;
+    if (display == NULL) {
+        return true;
+    }
+
+    max_profiles = vaMaxNumProfiles(display);
+    max_entrypoints = vaMaxNumEntrypoints(display);
+    if (max_profiles <= 0 || max_entrypoints <= 0) {
+        return true;
+    }
+    profiles = SDL_malloc((size_t)max_profiles * sizeof(*profiles));
+    entrypoints = SDL_malloc((size_t)max_entrypoints * sizeof(*entrypoints));
+    if (profiles == NULL || entrypoints == NULL) {
+        goto cleanup;
+    }
+
+    profile_count = max_profiles;
+    if (vaQueryConfigProfiles(display, profiles, &profile_count) != VA_STATUS_SUCCESS) {
+        goto cleanup;
+    }
+
+    for (Sint32 i = 0; i < profile_count; i++) {
+        VAConfigAttrib attributes[2] = {
+            { .type = VAConfigAttribMaxPictureWidth },
+            { .type = VAConfigAttribMaxPictureHeight },
+        };
+        const char *profile_name = vaProfileStr(profiles[i]);
+
+        if (!vdi_stream_client__parsec_ffmpeg_vaapi_profile_matches_codec(codec_id, profile_name) ||
+            !vdi_stream_client__parsec_ffmpeg_vaapi_profile_decode(
+                display, profiles[i], entrypoints, max_entrypoints
+            )) {
+            continue;
+        }
+        if (vaGetConfigAttributes(display, profiles[i], VAEntrypointVLD, attributes, 2) !=
+            VA_STATUS_SUCCESS) {
+            continue;
+        }
+        if (attributes[0].value == VA_ATTRIB_NOT_SUPPORTED ||
+            attributes[1].value == VA_ATTRIB_NOT_SUPPORTED || attributes[0].value <= 0 ||
+            attributes[1].value <= 0) {
+            continue;
+        }
+
+        found_limits = true;
+        if (coded_width <= (int)attributes[0].value && coded_height <= (int)attributes[1].value) {
+            supported = true;
+            break;
+        }
+    }
+
+cleanup:
+    SDL_free(entrypoints);
+    SDL_free(profiles);
+    return found_limits ? supported : true;
+}
+
+static enum AVPixelFormat
+vdi_stream_client__parsec_ffmpeg_raise_current_resolution_reset(
+    AVCodecContext *codec, struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg,
+    const enum AVPixelFormat *formats
+)
+{
+    return vdi_stream_client__parsec_ffmpeg_raise_resolution_reset(
+        codec, formats, ffmpeg != NULL ? ffmpeg->configured_width : 0,
+        ffmpeg != NULL ? ffmpeg->configured_height : 0
+    );
 }
 
 static bool
@@ -1123,6 +1240,17 @@ vdi_stream_client__parsec_ffmpeg_create_hw_frames(
 
     if (ffmpeg == NULL || ffmpeg->hw_device_ctx == NULL ||
         !vdi_stream_client__parsec_ffmpeg_coded_size(codec, &target_width, &target_height)) {
+        return false;
+    }
+    if (!vdi_stream_client__parsec_ffmpeg_vaapi_size_supported(
+            ffmpeg->hw_device_ctx, ffmpeg->codec_id, target_width, target_height
+        )) {
+        SDL_LogWarn(
+            SDL_LOG_CATEGORY_APPLICATION,
+            "Reject unsupported FFmpeg VA-API image size %dx%d coded %dx%d before frame-pool "
+            "setup\n",
+            codec->width, codec->height, target_width, target_height
+        );
         return false;
     }
     err = avcodec_get_hw_frames_parameters(
@@ -1236,7 +1364,23 @@ vdi_stream_client__parsec_ffmpeg_get_hw_format(
             vdi_stream_client__parsec_ffmpeg_coded_size(codec, &coded_width, &coded_height);
 
         if (reconfigure && reset_enabled && !manual_hw_frames) {
-            return vdi_stream_client__parsec_ffmpeg_raise_resolution_reset(codec, formats);
+            return vdi_stream_client__parsec_ffmpeg_raise_resolution_reset(
+                codec, formats, codec->width, codec->height
+            );
+        }
+        if (reconfigure && reset_enabled &&
+            !vdi_stream_client__parsec_ffmpeg_vaapi_size_supported(
+                ffmpeg->hw_device_ctx, ffmpeg->codec_id, coded_width, coded_height
+            )) {
+            SDL_LogWarn(
+                SDL_LOG_CATEGORY_APPLICATION,
+                "Reject unsupported RADV VA-API resize to %dx%d coded %dx%d; keep current %dx%d\n",
+                codec->width, codec->height, coded_width, coded_height, ffmpeg->configured_width,
+                ffmpeg->configured_height
+            );
+            return vdi_stream_client__parsec_ffmpeg_raise_current_resolution_reset(
+                codec, ffmpeg, formats
+            );
         }
         if (reconfigure && reset_enabled && manual_hw_frames &&
             vdi_stream_client__parsec_ffmpeg_resolution_grows(codec, ffmpeg)) {
@@ -1246,7 +1390,9 @@ vdi_stream_client__parsec_ffmpeg_get_hw_format(
                 ffmpeg->configured_coded_width, ffmpeg->configured_coded_height, coded_width,
                 coded_height
             );
-            return vdi_stream_client__parsec_ffmpeg_raise_resolution_reset(codec, formats);
+            return vdi_stream_client__parsec_ffmpeg_raise_resolution_reset(
+                codec, formats, codec->width, codec->height
+            );
         }
         if (manual_hw_frames) {
             if (reconfigure) {
@@ -1255,6 +1401,8 @@ vdi_stream_client__parsec_ffmpeg_get_hw_format(
             if (vdi_stream_client__parsec_ffmpeg_select_hw_frames(
                     codec, ffmpeg, !reconfigure || !reset_enabled
                 )) {
+                ffmpeg->configured_width = codec->width;
+                ffmpeg->configured_height = codec->height;
                 if (have_coded_size) {
                     ffmpeg->configured_coded_width = coded_width;
                     ffmpeg->configured_coded_height = coded_height;
@@ -1276,10 +1424,14 @@ vdi_stream_client__parsec_ffmpeg_get_hw_format(
                 return ffmpeg->hw_pix_fmt;
             }
             if (reconfigure && reset_enabled) {
-                return vdi_stream_client__parsec_ffmpeg_raise_resolution_reset(codec, formats);
+                return vdi_stream_client__parsec_ffmpeg_raise_resolution_reset(
+                    codec, formats, codec->width, codec->height
+                );
             }
         }
 
+        ffmpeg->configured_width = codec->width;
+        ffmpeg->configured_height = codec->height;
         if (have_coded_size) {
             ffmpeg->configured_coded_width = coded_width;
             ffmpeg->configured_coded_height = coded_height;

--- a/src/ffmpeg.c
+++ b/src/ffmpeg.c
@@ -54,6 +54,8 @@
 #define VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_MAGIC 0x56444646u
 #define VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_VERSION 1u
 #define VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_SLOTS 16u
+#define VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_ALIGNMENT 16
+#define VDI_STREAM_CLIENT_PARSEC_FFMPEG_POOL_FALLBACK_FRAMES 8
 
 /* The public Parsec frame callback only carries a raw image pointer. For FFmpeg
  * frames, carry a small descriptor through that buffer so the renderer can
@@ -81,11 +83,15 @@ struct vdi_stream_client__parsec_ffmpeg_decoder_s
     AVFrame *sw_frame;
     AVPacket *packet;
     AVBufferRef *hw_device_ctx;
+    AVBufferRef *hw_frames_ctx;
     enum AVCodecID codec_id;
     enum AVPixelFormat hw_pix_fmt;
     bool hwaccel;
+    bool manual_hw_frames;
     bool mode_published;
     bool format_configured;
+    int configured_coded_width;
+    int configured_coded_height;
     SDL_Mutex *frame_lock;
     struct vdi_stream_client__parsec_ffmpeg_frame_slot_s
         frame_slots[VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_SLOTS];
@@ -119,16 +125,11 @@ static SDL_Mutex *vdi_stream_client__parsec_ffmpeg_decoder_lock;
 static struct vdi_stream_client__parsec_ffmpeg_decoder_s
     *vdi_stream_client__parsec_ffmpeg_decoder_cache;
 
-/* Resolution-change coordination (AMD/RADV only). The RADV renderer and the
- * VA-API decoder are deduplicated by libdrm onto one in-process amdgpu device,
- * whose GPU address space fragments across a session. After a mid-stream
- * resolution change the larger working set no longer fits and the decode
- * submission is rejected with -ENOMEM. The only way to defragment is to release
- * BOTH references to the shared device (tear the renderer down and free the
- * decoder, closing the drm file) and rebuild fresh. The get_format callback
- * detects the change from the bitstream and returns AV_PIX_FMT_NONE so avcodec
- * aborts before allocating the new surface pool (avoiding the crash), and raises
- * this flag for the main thread to perform the full reset. */
+/* Resolution-change coordination (AMD/RADV only). The normal path keeps the
+ * first VA-API frame pool alive so stream-size reductions can reuse it. If the
+ * stream grows after a reduction, or manual pool setup fails during a
+ * reconfigure, get_format raises this flag so the main thread can fall back to
+ * the existing full reset. */
 static atomic_bool vdi_stream_client__parsec_ffmpeg_reset_enabled;
 static atomic_bool vdi_stream_client__parsec_ffmpeg_resolution_change;
 static atomic_bool vdi_stream_client__parsec_ffmpeg_aborting_decode;
@@ -138,6 +139,16 @@ static atomic_int vdi_stream_client__parsec_ffmpeg_target_height;
 static const char *vdi_stream_client__parsec_ffmpeg_error(Sint32 errnum, char *buffer, size_t len);
 static void
 vdi_stream_client__parsec_ffmpeg_free(struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg);
+
+static int
+vdi_stream_client__parsec_ffmpeg_align_dimension(int value)
+{
+    if (value <= 0 || value > INT_MAX - (VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_ALIGNMENT - 1)) {
+        return 0;
+    }
+    return (value + (VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_ALIGNMENT - 1)) &
+           ~(VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_ALIGNMENT - 1);
+}
 
 /* Enable resolution-change coordination, used only by the AMD/RADV linear path
  * whose shared amdgpu device fragments. Other drivers leave it disabled. */
@@ -205,8 +216,8 @@ vdi_stream_client__parsec_ffmpeg_resume_decode(void)
     );
 }
 
-/* Release every retained frame slot so a reused decoder does not keep the
- * previous stream's hardware surfaces referenced after a reconnect. */
+/* Release every retained frame slot so a reused decoder does not keep stale
+ * hardware surfaces referenced after reconnect or in-stream reconfiguration. */
 static void
 vdi_stream_client__parsec_ffmpeg_reset_frames(
     struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg
@@ -220,9 +231,28 @@ vdi_stream_client__parsec_ffmpeg_reset_frames(
         av_frame_free(&ffmpeg->frame_slots[i].frame);
         ffmpeg->frame_slots[i].generation = 0;
     }
-    ffmpeg->frame_generation = 0;
     ffmpeg->frame_slot = 0;
     SDL_UnlockMutex(ffmpeg->frame_lock);
+}
+
+/* Release every frame reference owned outside libavcodec's current decode state.
+ * This is used before an in-stream reconfigure so old VA surfaces are not held by
+ * descriptor slots while the decoder continues with the reusable pool. */
+static void
+vdi_stream_client__parsec_ffmpeg_release_frame_refs(
+    struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg
+)
+{
+    if (ffmpeg == NULL) {
+        return;
+    }
+    vdi_stream_client__parsec_ffmpeg_reset_frames(ffmpeg);
+    if (ffmpeg->frame != NULL) {
+        av_frame_unref(ffmpeg->frame);
+    }
+    if (ffmpeg->sw_frame != NULL) {
+        av_frame_unref(ffmpeg->sw_frame);
+    }
 }
 
 /* Return the CPU-visible pixel format for an AVFrame. VA-API frames expose this
@@ -946,9 +976,238 @@ vdi_stream_client__parsec_ffmpeg_error(Sint32 errnum, char *buffer, size_t len)
     return buffer;
 }
 
+static bool
+vdi_stream_client__parsec_ffmpeg_vaapi_manual_hw_frames(AVBufferRef *device_ref)
+{
+    AVHWDeviceContext *device_context;
+    AVVAAPIDeviceContext *vaapi_context;
+    const char *vendor;
+
+    if (device_ref == NULL || device_ref->data == NULL) {
+        return false;
+    }
+    device_context = (AVHWDeviceContext *)device_ref->data;
+    if (device_context->type != AV_HWDEVICE_TYPE_VAAPI) {
+        return false;
+    }
+    vaapi_context = (AVVAAPIDeviceContext *)device_context->hwctx;
+    if (vaapi_context == NULL || vaapi_context->display == NULL) {
+        return false;
+    }
+    vendor = vaQueryVendorString(vaapi_context->display);
+    return vendor != NULL && SDL_strstr(vendor, "Mesa Gallium driver") != NULL &&
+           (SDL_strstr(vendor, "AMD") != NULL || SDL_strstr(vendor, "Radeon") != NULL ||
+            SDL_strstr(vendor, "radeonsi") != NULL);
+}
+
+static bool
+vdi_stream_client__parsec_ffmpeg_hw_format_offered(
+    enum AVPixelFormat hw_pix_fmt, const enum AVPixelFormat *formats
+)
+{
+    const enum AVPixelFormat *format;
+
+    for (format = formats; format != NULL && *format != AV_PIX_FMT_NONE; format++) {
+        if (*format == hw_pix_fmt) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static enum AVPixelFormat
+vdi_stream_client__parsec_ffmpeg_first_software_format(const enum AVPixelFormat *formats)
+{
+    const enum AVPixelFormat *format;
+
+    for (format = formats; format != NULL && *format != AV_PIX_FMT_NONE; format++) {
+        const AVPixFmtDescriptor *descriptor = av_pix_fmt_desc_get(*format);
+
+        if (descriptor != NULL && (descriptor->flags & AV_PIX_FMT_FLAG_HWACCEL) == 0) {
+            return *format;
+        }
+    }
+    return AV_PIX_FMT_NONE;
+}
+
+static enum AVPixelFormat
+vdi_stream_client__parsec_ffmpeg_raise_resolution_reset(
+    AVCodecContext *codec, const enum AVPixelFormat *formats
+)
+{
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_target_width, codec->width, memory_order_relaxed
+    );
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_target_height, codec->height, memory_order_relaxed
+    );
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_aborting_decode, true, memory_order_release
+    );
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_resolution_change, true, memory_order_release
+    );
+    return vdi_stream_client__parsec_ffmpeg_first_software_format(formats);
+}
+
+static bool
+vdi_stream_client__parsec_ffmpeg_coded_size(AVCodecContext *codec, int *width, int *height)
+{
+    int coded_width;
+    int coded_height;
+
+    if (codec == NULL) {
+        return false;
+    }
+    coded_width = codec->coded_width > 0 ? codec->coded_width : codec->width;
+    coded_height = codec->coded_height > 0 ? codec->coded_height : codec->height;
+    coded_width = vdi_stream_client__parsec_ffmpeg_align_dimension(coded_width);
+    coded_height = vdi_stream_client__parsec_ffmpeg_align_dimension(coded_height);
+    if (coded_width <= 0 || coded_height <= 0) {
+        return false;
+    }
+    *width = coded_width;
+    *height = coded_height;
+    return true;
+}
+
+static bool
+vdi_stream_client__parsec_ffmpeg_resolution_grows(
+    AVCodecContext *codec, const struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg
+)
+{
+    int coded_width;
+    int coded_height;
+
+    if (ffmpeg == NULL || ffmpeg->configured_coded_width <= 0 ||
+        ffmpeg->configured_coded_height <= 0 ||
+        !vdi_stream_client__parsec_ffmpeg_coded_size(codec, &coded_width, &coded_height)) {
+        return false;
+    }
+    return coded_width > ffmpeg->configured_coded_width ||
+           coded_height > ffmpeg->configured_coded_height;
+}
+
+static bool
+vdi_stream_client__parsec_ffmpeg_hw_frames_compatible(
+    AVCodecContext *codec, struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg
+)
+{
+    AVHWFramesContext *cached_context;
+    int target_width;
+    int target_height;
+
+    if (ffmpeg == NULL || ffmpeg->hw_frames_ctx == NULL ||
+        !vdi_stream_client__parsec_ffmpeg_coded_size(codec, &target_width, &target_height)) {
+        return false;
+    }
+
+    cached_context = (AVHWFramesContext *)ffmpeg->hw_frames_ctx->data;
+    return cached_context != NULL && cached_context->format == ffmpeg->hw_pix_fmt &&
+           cached_context->width >= target_width && cached_context->height >= target_height;
+}
+
+static bool
+vdi_stream_client__parsec_ffmpeg_create_hw_frames(
+    AVCodecContext *codec, struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg
+)
+{
+    AVBufferRef *frames_ref = NULL;
+    AVBufferRef *cache_ref = NULL;
+    AVHWFramesContext *frames_context;
+    int target_width;
+    int target_height;
+    int pool_size;
+    Sint32 err;
+    char errbuf[AV_ERROR_MAX_STRING_SIZE];
+
+    if (ffmpeg == NULL || ffmpeg->hw_device_ctx == NULL ||
+        !vdi_stream_client__parsec_ffmpeg_coded_size(codec, &target_width, &target_height)) {
+        return false;
+    }
+    err = avcodec_get_hw_frames_parameters(
+        codec, ffmpeg->hw_device_ctx, ffmpeg->hw_pix_fmt, &frames_ref
+    );
+    if (err < 0 || frames_ref == NULL) {
+        SDL_LogWarn(
+            SDL_LOG_CATEGORY_APPLICATION, "FFmpeg VA-API frame parameters failed: %s\n",
+            vdi_stream_client__parsec_ffmpeg_error(err, errbuf, sizeof(errbuf))
+        );
+        return false;
+    }
+
+    frames_context = (AVHWFramesContext *)frames_ref->data;
+    if (frames_context == NULL) {
+        av_buffer_unref(&frames_ref);
+        return false;
+    }
+    frames_context->width = target_width;
+    frames_context->height = target_height;
+    pool_size = frames_context->initial_pool_size;
+    if (pool_size < 0) {
+        pool_size = 0;
+    }
+    if (pool_size > INT_MAX - (int)VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_SLOTS) {
+        av_buffer_unref(&frames_ref);
+        return false;
+    }
+    pool_size += (int)VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_SLOTS;
+    if (pool_size < (int)VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_SLOTS +
+                        VDI_STREAM_CLIENT_PARSEC_FFMPEG_POOL_FALLBACK_FRAMES) {
+        pool_size = (int)VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_SLOTS +
+                    VDI_STREAM_CLIENT_PARSEC_FFMPEG_POOL_FALLBACK_FRAMES;
+    }
+    frames_context->initial_pool_size = pool_size;
+
+    err = av_hwframe_ctx_init(frames_ref);
+    if (err < 0) {
+        SDL_LogWarn(
+            SDL_LOG_CATEGORY_APPLICATION, "FFmpeg VA-API frame pool setup failed: %s\n",
+            vdi_stream_client__parsec_ffmpeg_error(err, errbuf, sizeof(errbuf))
+        );
+        av_buffer_unref(&frames_ref);
+        return false;
+    }
+    cache_ref = av_buffer_ref(frames_ref);
+    if (cache_ref == NULL) {
+        av_buffer_unref(&frames_ref);
+        return false;
+    }
+
+    av_buffer_unref(&ffmpeg->hw_frames_ctx);
+    ffmpeg->hw_frames_ctx = cache_ref;
+    av_buffer_unref(&codec->hw_frames_ctx);
+    codec->hw_frames_ctx = frames_ref;
+    frames_ref = NULL;
+    SDL_LogInfo(
+        SDL_LOG_CATEGORY_APPLICATION,
+        "Preallocate VA-API hardware frames at %dx%d with %d surfaces\n", target_width,
+        target_height, pool_size
+    );
+    return true;
+}
+
+static bool
+vdi_stream_client__parsec_ffmpeg_select_hw_frames(
+    AVCodecContext *codec, struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg,
+    bool allow_create
+)
+{
+    if (ffmpeg == NULL) {
+        return false;
+    }
+    if (vdi_stream_client__parsec_ffmpeg_hw_frames_compatible(codec, ffmpeg)) {
+        av_buffer_unref(&codec->hw_frames_ctx);
+        codec->hw_frames_ctx = av_buffer_ref(ffmpeg->hw_frames_ctx);
+        return codec->hw_frames_ctx != NULL;
+    }
+    return allow_create && vdi_stream_client__parsec_ffmpeg_create_hw_frames(codec, ffmpeg);
+}
+
 /* FFmpeg get_format callback that selects the VA-API hardware pixel format
- * discovered during decoder initialization, falling back to FFmpeg's first
- * offered format if the expected one is absent. */
+ * discovered during decoder initialization. On AMD/Mesa VA-API, it reuses the
+ * cached manual frame pool for in-stream downscales and keeps the existing reset
+ * path for upscales and setup failures. */
 static enum AVPixelFormat
 vdi_stream_client__parsec_ffmpeg_get_hw_format(
     AVCodecContext *codec, const enum AVPixelFormat *formats
@@ -956,51 +1215,77 @@ vdi_stream_client__parsec_ffmpeg_get_hw_format(
 {
     struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg =
         codec != NULL ? codec->opaque : NULL;
-    const enum AVPixelFormat *format;
+    bool reconfigure;
+    bool reset_enabled;
+    bool manual_hw_frames;
+    bool have_coded_size;
+    int coded_width = 0;
+    int coded_height = 0;
 
-    /* avcodec calls get_format whenever it (re)configures for the stream's pixel
-     * format and dimensions, immediately before allocating the hardware surface
-     * pool. The first call is the initial setup; any later call is a resolution
-     * change. On the AMD/RADV path the hardware pool reallocation would be
-     * rejected on the fragmented shared amdgpu device, so raise the flag for the
-     * main thread to perform the full pipeline reset and choose a software format
-     * for this one packet. Software decoding allocates no hardware pool (avoiding
-     * the crash) and still produces a frame, so avcodec never logs "no frame!";
-     * the decoded frame is discarded because the reset flag is set. */
     if (ffmpeg != NULL) {
-        if (ffmpeg->format_configured &&
-            atomic_load_explicit(
-                &vdi_stream_client__parsec_ffmpeg_reset_enabled, memory_order_acquire
-            )) {
-            atomic_store_explicit(
-                &vdi_stream_client__parsec_ffmpeg_target_width, codec->width, memory_order_relaxed
-            );
-            atomic_store_explicit(
-                &vdi_stream_client__parsec_ffmpeg_target_height, codec->height, memory_order_relaxed
-            );
-            atomic_store_explicit(
-                &vdi_stream_client__parsec_ffmpeg_aborting_decode, true, memory_order_release
-            );
-            atomic_store_explicit(
-                &vdi_stream_client__parsec_ffmpeg_resolution_change, true, memory_order_release
-            );
+        if (!vdi_stream_client__parsec_ffmpeg_hw_format_offered(ffmpeg->hw_pix_fmt, formats)) {
+            return formats != NULL ? formats[0] : AV_PIX_FMT_NONE;
+        }
 
-            for (format = formats; format != NULL && *format != AV_PIX_FMT_NONE; format++) {
-                const AVPixFmtDescriptor *descriptor = av_pix_fmt_desc_get(*format);
+        reconfigure = ffmpeg->format_configured;
+        reset_enabled = atomic_load_explicit(
+            &vdi_stream_client__parsec_ffmpeg_reset_enabled, memory_order_acquire
+        );
+        manual_hw_frames = ffmpeg->manual_hw_frames;
+        have_coded_size =
+            vdi_stream_client__parsec_ffmpeg_coded_size(codec, &coded_width, &coded_height);
 
-                if (descriptor != NULL && (descriptor->flags & AV_PIX_FMT_FLAG_HWACCEL) == 0) {
-                    return *format;
-                }
+        if (reconfigure && reset_enabled && !manual_hw_frames) {
+            return vdi_stream_client__parsec_ffmpeg_raise_resolution_reset(codec, formats);
+        }
+        if (reconfigure && reset_enabled && manual_hw_frames &&
+            vdi_stream_client__parsec_ffmpeg_resolution_grows(codec, ffmpeg)) {
+            SDL_LogInfo(
+                SDL_LOG_CATEGORY_APPLICATION,
+                "Use resolution reset fallback for RADV VA-API upscale from coded %dx%d to %dx%d\n",
+                ffmpeg->configured_coded_width, ffmpeg->configured_coded_height, coded_width,
+                coded_height
+            );
+            return vdi_stream_client__parsec_ffmpeg_raise_resolution_reset(codec, formats);
+        }
+        if (manual_hw_frames) {
+            if (reconfigure) {
+                vdi_stream_client__parsec_ffmpeg_release_frame_refs(ffmpeg);
             }
-            return AV_PIX_FMT_NONE;
+            if (vdi_stream_client__parsec_ffmpeg_select_hw_frames(
+                    codec, ffmpeg, !reconfigure || !reset_enabled
+                )) {
+                if (have_coded_size) {
+                    ffmpeg->configured_coded_width = coded_width;
+                    ffmpeg->configured_coded_height = coded_height;
+                }
+                if (reconfigure) {
+                    AVHWFramesContext *frames_context =
+                        codec->hw_frames_ctx != NULL
+                            ? (AVHWFramesContext *)codec->hw_frames_ctx->data
+                            : NULL;
+                    SDL_LogInfo(
+                        SDL_LOG_CATEGORY_APPLICATION,
+                        "Reconfigure FFmpeg VA-API decoder to %dx%d coded %dx%d using %dx%d pool\n",
+                        codec->width, codec->height, coded_width, coded_height,
+                        frames_context != NULL ? frames_context->width : 0,
+                        frames_context != NULL ? frames_context->height : 0
+                    );
+                }
+                ffmpeg->format_configured = true;
+                return ffmpeg->hw_pix_fmt;
+            }
+            if (reconfigure && reset_enabled) {
+                return vdi_stream_client__parsec_ffmpeg_raise_resolution_reset(codec, formats);
+            }
+        }
+
+        if (have_coded_size) {
+            ffmpeg->configured_coded_width = coded_width;
+            ffmpeg->configured_coded_height = coded_height;
         }
         ffmpeg->format_configured = true;
-
-        for (format = formats; format != NULL && *format != AV_PIX_FMT_NONE; format++) {
-            if (*format == ffmpeg->hw_pix_fmt) {
-                return *format;
-            }
-        }
+        return ffmpeg->hw_pix_fmt;
     }
 
     return formats != NULL ? formats[0] : AV_PIX_FMT_NONE;
@@ -1051,6 +1336,8 @@ vdi_stream_client__parsec_ffmpeg_setup_vaapi(
     }
     ffmpeg->codec->opaque = ffmpeg;
     ffmpeg->codec->get_format = vdi_stream_client__parsec_ffmpeg_get_hw_format;
+    ffmpeg->manual_hw_frames =
+        vdi_stream_client__parsec_ffmpeg_vaapi_manual_hw_frames(ffmpeg->hw_device_ctx);
     ffmpeg->hwaccel = true;
     return true;
 }
@@ -1131,6 +1418,7 @@ vdi_stream_client__parsec_ffmpeg_free(struct vdi_stream_client__parsec_ffmpeg_de
     av_frame_free(&ffmpeg->sw_frame);
     av_frame_free(&ffmpeg->frame);
     avcodec_free_context(&ffmpeg->codec);
+    av_buffer_unref(&ffmpeg->hw_frames_ctx);
     av_buffer_unref(&ffmpeg->hw_device_ctx);
     SDL_free(ffmpeg);
 }
@@ -1235,6 +1523,7 @@ vdi_stream_client__parsec_ffmpeg_init_common(
         avcodec_free_context(&ffmpeg->codec);
         av_buffer_unref(&ffmpeg->hw_device_ctx);
         ffmpeg->hwaccel = false;
+        ffmpeg->manual_hw_frames = false;
         ffmpeg->hw_pix_fmt = AV_PIX_FMT_NONE;
 
         ffmpeg->codec = avcodec_alloc_context3(codec);

--- a/src/ffmpeg.c
+++ b/src/ffmpeg.c
@@ -1307,11 +1307,6 @@ vdi_stream_client__parsec_ffmpeg_create_hw_frames(
     av_buffer_unref(&codec->hw_frames_ctx);
     codec->hw_frames_ctx = frames_ref;
     frames_ref = NULL;
-    SDL_LogInfo(
-        SDL_LOG_CATEGORY_APPLICATION,
-        "Preallocate VA-API hardware frames at %dx%d with %d surfaces\n", target_width,
-        target_height, pool_size
-    );
     return true;
 }
 
@@ -1386,7 +1381,7 @@ vdi_stream_client__parsec_ffmpeg_get_hw_format(
             vdi_stream_client__parsec_ffmpeg_resolution_grows(codec, ffmpeg)) {
             SDL_LogInfo(
                 SDL_LOG_CATEGORY_APPLICATION,
-                "Use resolution reset fallback for RADV VA-API upscale from coded %dx%d to %dx%d\n",
+                "Reconfigure FFmpeg VA-API decoder from coded %dx%d to %dx%d\n",
                 ffmpeg->configured_coded_width, ffmpeg->configured_coded_height, coded_width,
                 coded_height
             );

--- a/src/ffmpeg.c
+++ b/src/ffmpeg.c
@@ -85,6 +85,7 @@ struct vdi_stream_client__parsec_ffmpeg_decoder_s
     enum AVPixelFormat hw_pix_fmt;
     bool hwaccel;
     bool mode_published;
+    bool format_configured;
     SDL_Mutex *frame_lock;
     struct vdi_stream_client__parsec_ffmpeg_frame_slot_s
         frame_slots[VDI_STREAM_CLIENT_PARSEC_FFMPEG_FRAME_SLOTS];
@@ -118,9 +119,91 @@ static SDL_Mutex *vdi_stream_client__parsec_ffmpeg_decoder_lock;
 static struct vdi_stream_client__parsec_ffmpeg_decoder_s
     *vdi_stream_client__parsec_ffmpeg_decoder_cache;
 
+/* Resolution-change coordination (AMD/RADV only). The RADV renderer and the
+ * VA-API decoder are deduplicated by libdrm onto one in-process amdgpu device,
+ * whose GPU address space fragments across a session. After a mid-stream
+ * resolution change the larger working set no longer fits and the decode
+ * submission is rejected with -ENOMEM. The only way to defragment is to release
+ * BOTH references to the shared device (tear the renderer down and free the
+ * decoder, closing the drm file) and rebuild fresh. The get_format callback
+ * detects the change from the bitstream and returns AV_PIX_FMT_NONE so avcodec
+ * aborts before allocating the new surface pool (avoiding the crash), and raises
+ * this flag for the main thread to perform the full reset. */
+static atomic_bool vdi_stream_client__parsec_ffmpeg_reset_enabled;
+static atomic_bool vdi_stream_client__parsec_ffmpeg_resolution_change;
+static atomic_bool vdi_stream_client__parsec_ffmpeg_aborting_decode;
+static atomic_int vdi_stream_client__parsec_ffmpeg_target_width;
+static atomic_int vdi_stream_client__parsec_ffmpeg_target_height;
+
 static const char *vdi_stream_client__parsec_ffmpeg_error(Sint32 errnum, char *buffer, size_t len);
 static void
 vdi_stream_client__parsec_ffmpeg_free(struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg);
+
+/* Enable resolution-change coordination, used only by the AMD/RADV linear path
+ * whose shared amdgpu device fragments. Other drivers leave it disabled. */
+void
+vdi_stream_client__parsec_ffmpeg_enable_resolution_reset(bool enable)
+{
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_reset_enabled, enable, memory_order_release
+    );
+}
+
+/* Main-thread query and clear for a pending resolution-change reset. */
+bool
+vdi_stream_client__parsec_ffmpeg_resolution_reset_pending(void)
+{
+    return atomic_exchange_explicit(
+        &vdi_stream_client__parsec_ffmpeg_resolution_change, false, memory_order_acq_rel
+    );
+}
+
+/* Report the resolution the decoder was reconfiguring to when the reset was
+ * raised. The reconnect requests it so the host keeps the new resolution instead
+ * of reverting to the client's previous size. Returns false if unknown. */
+bool
+vdi_stream_client__parsec_ffmpeg_target_resolution(int *width, int *height)
+{
+    int w =
+        atomic_load_explicit(&vdi_stream_client__parsec_ffmpeg_target_width, memory_order_acquire);
+    int h =
+        atomic_load_explicit(&vdi_stream_client__parsec_ffmpeg_target_height, memory_order_acquire);
+
+    if (w <= 0 || h <= 0) {
+        return false;
+    }
+    *width = w;
+    *height = h;
+    return true;
+}
+
+/* Free the cached decoder so the next connect builds a fresh one with a new
+ * VA-API device. Call only after the Parsec client has been disconnected, so no
+ * decode thread is using the decoder. Releases this process's VA-API reference
+ * to the shared amdgpu device. */
+void
+vdi_stream_client__parsec_ffmpeg_invalidate_decoder(void)
+{
+    if (vdi_stream_client__parsec_ffmpeg_decoder_lock == NULL) {
+        return;
+    }
+    SDL_LockMutex(vdi_stream_client__parsec_ffmpeg_decoder_lock);
+    if (vdi_stream_client__parsec_ffmpeg_decoder_cache != NULL) {
+        vdi_stream_client__parsec_ffmpeg_free(vdi_stream_client__parsec_ffmpeg_decoder_cache);
+        vdi_stream_client__parsec_ffmpeg_decoder_cache = NULL;
+    }
+    SDL_UnlockMutex(vdi_stream_client__parsec_ffmpeg_decoder_lock);
+}
+
+/* Resume feeding packets to the decoder after a resolution-change reset has
+ * rebuilt it, clearing the flag that skipped decodes during the reset. */
+void
+vdi_stream_client__parsec_ffmpeg_resume_decode(void)
+{
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_aborting_decode, false, memory_order_release
+    );
+}
 
 /* Release every retained frame slot so a reused decoder does not keep the
  * previous stream's hardware surfaces referenced after a reconnect. */
@@ -875,7 +958,44 @@ vdi_stream_client__parsec_ffmpeg_get_hw_format(
         codec != NULL ? codec->opaque : NULL;
     const enum AVPixelFormat *format;
 
+    /* avcodec calls get_format whenever it (re)configures for the stream's pixel
+     * format and dimensions, immediately before allocating the hardware surface
+     * pool. The first call is the initial setup; any later call is a resolution
+     * change. On the AMD/RADV path the hardware pool reallocation would be
+     * rejected on the fragmented shared amdgpu device, so raise the flag for the
+     * main thread to perform the full pipeline reset and choose a software format
+     * for this one packet. Software decoding allocates no hardware pool (avoiding
+     * the crash) and still produces a frame, so avcodec never logs "no frame!";
+     * the decoded frame is discarded because the reset flag is set. */
     if (ffmpeg != NULL) {
+        if (ffmpeg->format_configured &&
+            atomic_load_explicit(
+                &vdi_stream_client__parsec_ffmpeg_reset_enabled, memory_order_acquire
+            )) {
+            atomic_store_explicit(
+                &vdi_stream_client__parsec_ffmpeg_target_width, codec->width, memory_order_relaxed
+            );
+            atomic_store_explicit(
+                &vdi_stream_client__parsec_ffmpeg_target_height, codec->height, memory_order_relaxed
+            );
+            atomic_store_explicit(
+                &vdi_stream_client__parsec_ffmpeg_aborting_decode, true, memory_order_release
+            );
+            atomic_store_explicit(
+                &vdi_stream_client__parsec_ffmpeg_resolution_change, true, memory_order_release
+            );
+
+            for (format = formats; format != NULL && *format != AV_PIX_FMT_NONE; format++) {
+                const AVPixFmtDescriptor *descriptor = av_pix_fmt_desc_get(*format);
+
+                if (descriptor != NULL && (descriptor->flags & AV_PIX_FMT_FLAG_HWACCEL) == 0) {
+                    return *format;
+                }
+            }
+            return AV_PIX_FMT_NONE;
+        }
+        ffmpeg->format_configured = true;
+
         for (format = formats; format != NULL && *format != AV_PIX_FMT_NONE; format++) {
             if (*format == ffmpeg->hw_pix_fmt) {
                 return *format;
@@ -1598,11 +1718,29 @@ vdi_stream_client__parsec_ffmpeg_decode(
         );
     }
 
+    /* While a resolution change is being reset, the decode context cannot accept
+     * packets: feeding them makes FFmpeg log "no frame!" and "get_buffer()
+     * failed". Skip them here so those errors are never produced. The flag is
+     * raised by get_format and cleared once the reset has rebuilt the decoder. */
+    if (atomic_load_explicit(
+            &vdi_stream_client__parsec_ffmpeg_aborting_decode, memory_order_acquire
+        )) {
+        return DECODE_WRN_ACCEPTED;
+    }
+
     av_packet_unref(ffmpeg->packet);
     ffmpeg->packet->data = (Uint8 *)packet_data;
     ffmpeg->packet->size = (int)packet_size;
 
     err = vdi_stream_client__parsec_ffmpeg_send_packet(ffmpeg->codec, ffmpeg->packet);
+
+    /* The packet that triggered the resolution change set the abort flag inside
+     * get_format; accept it quietly so the expected failure is not reported. */
+    if (atomic_load_explicit(
+            &vdi_stream_client__parsec_ffmpeg_aborting_decode, memory_order_acquire
+        )) {
+        return DECODE_WRN_ACCEPTED;
+    }
     if (err == AVERROR(EAGAIN)) {
         err = vdi_stream_client__parsec_ffmpeg_receive_frame(ffmpeg->codec, ffmpeg->frame);
         if (err == 0) {

--- a/src/ffmpeg.c
+++ b/src/ffmpeg.c
@@ -1404,10 +1404,9 @@ vdi_stream_client__parsec_ffmpeg_get_hw_format(
         have_coded_size =
             vdi_stream_client__parsec_ffmpeg_coded_size(codec, &coded_width, &coded_height);
 
-        if (!reconfigure &&
-            !vdi_stream_client__parsec_ffmpeg_vaapi_size_supported(
-                ffmpeg->hw_device_ctx, ffmpeg->codec_id, coded_width, coded_height
-            )) {
+        if (!reconfigure && !vdi_stream_client__parsec_ffmpeg_vaapi_size_supported(
+                                ffmpeg->hw_device_ctx, ffmpeg->codec_id, coded_width, coded_height
+                            )) {
             SDL_LogError(
                 SDL_LOG_CATEGORY_APPLICATION,
                 "Unsupported FFmpeg VA-API image size %dx%d coded %dx%d on this device\n",

--- a/src/ffmpeg.c
+++ b/src/ffmpeg.c
@@ -137,6 +137,9 @@ static atomic_bool vdi_stream_client__parsec_ffmpeg_resolution_change;
 static atomic_bool vdi_stream_client__parsec_ffmpeg_aborting_decode;
 static atomic_int vdi_stream_client__parsec_ffmpeg_target_width;
 static atomic_int vdi_stream_client__parsec_ffmpeg_target_height;
+static atomic_bool vdi_stream_client__parsec_ffmpeg_unsupported_startup;
+static atomic_int vdi_stream_client__parsec_ffmpeg_unsupported_width;
+static atomic_int vdi_stream_client__parsec_ffmpeg_unsupported_height;
 
 static const char *vdi_stream_client__parsec_ffmpeg_error(Sint32 errnum, char *buffer, size_t len);
 static void
@@ -187,6 +190,29 @@ vdi_stream_client__parsec_ffmpeg_target_resolution(int *width, int *height)
     }
     *width = w;
     *height = h;
+    return true;
+}
+
+bool
+vdi_stream_client__parsec_ffmpeg_unsupported_startup_size(int *width, int *height)
+{
+    bool pending = atomic_exchange_explicit(
+        &vdi_stream_client__parsec_ffmpeg_unsupported_startup, false, memory_order_acq_rel
+    );
+
+    if (!pending) {
+        return false;
+    }
+    if (width != NULL) {
+        *width = atomic_load_explicit(
+            &vdi_stream_client__parsec_ffmpeg_unsupported_width, memory_order_acquire
+        );
+    }
+    if (height != NULL) {
+        *height = atomic_load_explicit(
+            &vdi_stream_client__parsec_ffmpeg_unsupported_height, memory_order_acquire
+        );
+    }
     return true;
 }
 
@@ -1188,6 +1214,26 @@ vdi_stream_client__parsec_ffmpeg_raise_current_resolution_reset(
     );
 }
 
+static enum AVPixelFormat
+vdi_stream_client__parsec_ffmpeg_raise_unsupported_startup_size(
+    AVCodecContext *codec, const enum AVPixelFormat *formats
+)
+{
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_unsupported_width, codec->width, memory_order_relaxed
+    );
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_unsupported_height, codec->height, memory_order_relaxed
+    );
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_aborting_decode, true, memory_order_release
+    );
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_unsupported_startup, true, memory_order_release
+    );
+    return vdi_stream_client__parsec_ffmpeg_first_software_format(formats);
+}
+
 static bool
 vdi_stream_client__parsec_ffmpeg_resolution_grows(
     AVCodecContext *codec, const struct vdi_stream_client__parsec_ffmpeg_decoder_s *ffmpeg
@@ -1358,6 +1404,17 @@ vdi_stream_client__parsec_ffmpeg_get_hw_format(
         have_coded_size =
             vdi_stream_client__parsec_ffmpeg_coded_size(codec, &coded_width, &coded_height);
 
+        if (!reconfigure &&
+            !vdi_stream_client__parsec_ffmpeg_vaapi_size_supported(
+                ffmpeg->hw_device_ctx, ffmpeg->codec_id, coded_width, coded_height
+            )) {
+            SDL_LogError(
+                SDL_LOG_CATEGORY_APPLICATION,
+                "Unsupported FFmpeg VA-API image size %dx%d coded %dx%d on this device\n",
+                codec->width, codec->height, coded_width, coded_height
+            );
+            return vdi_stream_client__parsec_ffmpeg_raise_unsupported_startup_size(codec, formats);
+        }
         if (reconfigure && reset_enabled && !manual_hw_frames) {
             return vdi_stream_client__parsec_ffmpeg_raise_resolution_reset(
                 codec, formats, codec->width, codec->height
@@ -1596,6 +1653,15 @@ vdi_stream_client__parsec_ffmpeg_init_common(
 
     selector = codec_selector != NULL ? ((const Uint8 *)codec_selector)[0] : 2;
     requested_codec_id = selector == 2 ? AV_CODEC_ID_HEVC : AV_CODEC_ID_H264;
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_unsupported_startup, false, memory_order_release
+    );
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_unsupported_width, 0, memory_order_relaxed
+    );
+    atomic_store_explicit(
+        &vdi_stream_client__parsec_ffmpeg_unsupported_height, 0, memory_order_relaxed
+    );
 
     /* Reuse the decode context built on a previous connect when its codec still
      * matches. This keeps the proven VA-API/UVD context alive across reconnects

--- a/src/ffmpeg.h
+++ b/src/ffmpeg.h
@@ -59,4 +59,6 @@ bool vdi_stream_client__parsec_ffmpeg_decoder_enable(
     bool hevc_acceleration, bool color444
 );
 
+void vdi_stream_client__parsec_ffmpeg_decoder_destroy(void);
+
 #endif /* _FFMPEG_H */

--- a/src/ffmpeg.h
+++ b/src/ffmpeg.h
@@ -61,4 +61,10 @@ bool vdi_stream_client__parsec_ffmpeg_decoder_enable(
 
 void vdi_stream_client__parsec_ffmpeg_decoder_destroy(void);
 
+void vdi_stream_client__parsec_ffmpeg_enable_resolution_reset(bool enable);
+bool vdi_stream_client__parsec_ffmpeg_resolution_reset_pending(void);
+bool vdi_stream_client__parsec_ffmpeg_target_resolution(int *width, int *height);
+void vdi_stream_client__parsec_ffmpeg_invalidate_decoder(void);
+void vdi_stream_client__parsec_ffmpeg_resume_decode(void);
+
 #endif /* _FFMPEG_H */

--- a/src/ffmpeg.h
+++ b/src/ffmpeg.h
@@ -64,6 +64,7 @@ void vdi_stream_client__parsec_ffmpeg_decoder_destroy(void);
 void vdi_stream_client__parsec_ffmpeg_enable_resolution_reset(bool enable);
 bool vdi_stream_client__parsec_ffmpeg_resolution_reset_pending(void);
 bool vdi_stream_client__parsec_ffmpeg_target_resolution(int *width, int *height);
+bool vdi_stream_client__parsec_ffmpeg_unsupported_startup_size(int *width, int *height);
 void vdi_stream_client__parsec_ffmpeg_invalidate_decoder(void);
 void vdi_stream_client__parsec_ffmpeg_resume_decode(void);
 

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -137,6 +137,7 @@ vdi_stream_client__parsec_reconnect(
     vdi_stream_client__context_set_connection(parsec_context, false);
     parsec_context->requested_width = 0;
     parsec_context->requested_height = 0;
+    parsec_context->client_status = (ParsecClientStatus){ 0 };
     while (vdi_stream_client__context_audio_polling(parsec_context)) {
         SDL_Delay(1);
     }
@@ -148,6 +149,8 @@ vdi_stream_client__parsec_reconnect(
     e = ParsecClientConnect(parsec_context->parsec, cfg, vdi_config->session, vdi_config->peer);
     if (e != PARSEC_OK) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Reconnect failed with code: %d\n", e);
+    } else {
+        parsec_context->stream_error = PARSEC_OK;
     }
     return e;
 }
@@ -481,6 +484,7 @@ vdi_stream_client__render_text(void *opaque, const char *text)
         );
         return VDI_STREAM_CLIENT_ERROR;
     }
+    SDL_strlcpy(parsec_context->overlay_text, text, sizeof(parsec_context->overlay_text));
 
     /* No error. */
     return VDI_STREAM_CLIENT_SUCCESS;
@@ -677,6 +681,10 @@ vdi_stream_client__show_connection_overlay(
     struct parsec_context_s *parsec_context, bool *force_redraw, const char *text
 )
 {
+    if (parsec_context->surface_ttf != NULL &&
+        SDL_strcmp(parsec_context->overlay_text, text) == 0) {
+        return;
+    }
     vdi_stream_client__render_text(parsec_context, text);
     *force_redraw = true;
 }
@@ -757,7 +765,32 @@ vdi_stream_client__handle_connection_status(
     ParsecClientConfig *cfg, Uint64 *last_time, bool *force_redraw
 )
 {
-    ParsecStatus e = ParsecClientGetStatus(parsec_context->parsec, &parsec_context->client_status);
+    ParsecStatus e;
+
+    if (parsec_context->stream_error != PARSEC_OK) {
+        vdi_stream_client__context_set_connection(parsec_context, false);
+        parsec_context->requested_width = 0;
+        parsec_context->requested_height = 0;
+
+        if (vdi_config->reconnect == 0) {
+            vdi_stream_client__show_connection_overlay(parsec_context, force_redraw, "Closing...");
+            SDL_LogError(
+                SDL_LOG_CATEGORY_APPLICATION, "Parsec stream failed with code: %d\n",
+                parsec_context->stream_error
+            );
+            vdi_stream_client__context_set_done(parsec_context, true);
+            return;
+        }
+
+        vdi_stream_client__show_connection_overlay(parsec_context, force_redraw, "Reconnecting...");
+        if (SDL_GetTicks() > *last_time + vdi_config->timeout) {
+            (void)vdi_stream_client__parsec_reconnect(parsec_context, cfg, vdi_config);
+            *last_time = SDL_GetTicks();
+        }
+        return;
+    }
+
+    e = ParsecClientGetStatus(parsec_context->parsec, &parsec_context->client_status);
 
     if (vdi_config->reconnect == 0 && e != PARSEC_CONNECTING && e != PARSEC_OK) {
         vdi_stream_client__show_connection_overlay(parsec_context, force_redraw, "Closing...");

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -1408,6 +1408,9 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     /* Parsec destroy. */
     ParsecDestroy(parsec_context.parsec);
 
+    /* Release the reused decode context now that all decoders are gone. */
+    vdi_stream_client__parsec_ffmpeg_decoder_destroy();
+
     /* TTF destroy. */
     TTF_CloseFont(parsec_context.font);
     TTF_Quit();
@@ -1433,6 +1436,9 @@ error:
 
     /* Parsec destroy. */
     ParsecDestroy(parsec_context.parsec);
+
+    /* Release the reused decode context now that all decoders are gone. */
+    vdi_stream_client__parsec_ffmpeg_decoder_destroy();
 
     /* TTF destroy. */
     TTF_CloseFont(parsec_context.font);

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -904,6 +904,124 @@ vdi_stream_client__window_enforce_size(SDL_Window *window, Sint32 width, Sint32 
     vdi_stream_client__window_lock_size(window, width, height);
 }
 
+/* Fully reset the streaming pipeline for a mid-stream resolution change on the
+ * AMD/RADV path. The renderer and the VA-API decoder are deduplicated by libdrm
+ * onto one in-process amdgpu device whose address space fragments over a
+ * session, so once a resolution change needs a larger working set the decode
+ * submission is rejected. Releasing both references to the shared device (tear
+ * the renderer down and free the decoder, which closes the drm file) resets the
+ * kernel GPU context; a fresh connect then rebuilds the decoder on a clean
+ * device at the new resolution, and the renderer is recreated on top, exactly as
+ * on the first connect. The decode thread has already aborted its decode in
+ * get_format, so no decode is in flight here. */
+static void
+vdi_stream_client__resolution_reset(
+    struct parsec_context_s *parsec_context, ParsecClientConfig *cfg,
+    struct vdi_config_s *vdi_config
+)
+{
+    bool acceleration = parsec_context->placebo != NULL;
+    Uint32 wait_time = 0;
+    int target_width = 0;
+    int target_height = 0;
+    Sint32 previous_width = parsec_context->window_width;
+    Sint32 previous_height = parsec_context->window_height;
+    ParsecStatus e;
+
+    /* Request the resolution the host switched to so the reconnect keeps it
+     * instead of reverting to the client's previous size; the Parsec host
+     * display follows the client's requested resolution. */
+    if (vdi_stream_client__parsec_ffmpeg_target_resolution(&target_width, &target_height)) {
+        cfg->video[DEFAULT_STREAM].resolutionX = target_width;
+        cfg->video[DEFAULT_STREAM].resolutionY = target_height;
+    }
+
+    /* Stop streaming and let the audio and input workers leave the Parsec API. */
+    vdi_stream_client__context_set_connection(parsec_context, false);
+    while (vdi_stream_client__context_audio_polling(parsec_context)) {
+        SDL_Delay(1);
+    }
+    while (vdi_stream_client__context_input_polling(parsec_context)) {
+        SDL_Delay(1);
+    }
+
+    /* Release both references to the shared amdgpu device. The renderer is torn
+     * down first, then the client is disconnected so the SDK stops decoding, and
+     * finally the cached decoder is freed (closing the VA-API drm file). With no
+     * reference left, the kernel GPU context and its fragmented address space are
+     * destroyed. */
+    vdi_stream_client__video_destroy(parsec_context);
+    ParsecClientDisconnect(parsec_context->parsec);
+    vdi_stream_client__parsec_ffmpeg_invalidate_decoder();
+
+    /* The old decoder is gone; restore avcodec logging for the fresh decoder. */
+    vdi_stream_client__parsec_ffmpeg_resume_decode();
+
+    /* Reconnect: the SDK builds a fresh decoder with a new VA-API device on the
+     * now-defragmented shared device and negotiates the new resolution. */
+    parsec_context->requested_width = 0;
+    parsec_context->requested_height = 0;
+    parsec_context->client_status = (ParsecClientStatus){ 0 };
+    parsec_context->decoder = false;
+    e = ParsecClientConnect(parsec_context->parsec, cfg, vdi_config->session, vdi_config->peer);
+    if (e != PARSEC_OK) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Resolution reset reconnect failed: %d\n", e);
+        parsec_context->stream_error = e;
+        return;
+    }
+
+    while (!parsec_context->decoder && wait_time < vdi_config->timeout) {
+        e = ParsecClientGetStatus(parsec_context->parsec, &parsec_context->client_status);
+        if (e == PARSEC_OK && parsec_context->client_status.decoder[DEFAULT_STREAM].width > 0 &&
+            parsec_context->client_status.decoder[DEFAULT_STREAM].height > 0) {
+            parsec_context->window_width =
+                parsec_context->client_status.decoder[DEFAULT_STREAM].width;
+            parsec_context->window_height =
+                parsec_context->client_status.decoder[DEFAULT_STREAM].height;
+            parsec_context->decoder = true;
+            break;
+        }
+        if (e != PARSEC_CONNECTING && e != PARSEC_OK) {
+            break;
+        }
+        SDL_Delay(50);
+        wait_time += 50;
+    }
+
+    /* Match the in-place resolution-change message used on other drivers so the
+     * RADV reset path reports the change the same way. */
+    if (parsec_context->window_width != previous_width ||
+        parsec_context->window_height != previous_height) {
+        SDL_LogInfo(
+            SDL_LOG_CATEGORY_APPLICATION, "Change resolution from %dx%d to %dx%d\n", previous_width,
+            previous_height, parsec_context->window_width, parsec_context->window_height
+        );
+    }
+
+    /* Resize the window and rebuild the renderer on the fresh device. The fresh
+     * decoder has already allocated its surface pool while the renderer was
+     * absent, mirroring the first-connect allocation order. */
+    vdi_stream_client__window_unlock_size(parsec_context->window);
+    vdi_stream_client__window_enforce_size(
+        parsec_context->window, parsec_context->window_width, parsec_context->window_height
+    );
+    parsec_context->silent_reinit = true;
+    if (!vdi_stream_client__video_init(parsec_context, acceleration)) {
+        parsec_context->silent_reinit = false;
+        SDL_LogError(
+            SDL_LOG_CATEGORY_APPLICATION, "Resolution reset renderer rebuild failed: %s\n",
+            SDL_GetError()
+        );
+        parsec_context->stream_error = ERR_DEFAULT;
+        return;
+    }
+    parsec_context->silent_reinit = false;
+    if (parsec_context->overlay_text[0] != '\0') {
+        (void)vdi_stream_client__render_text(parsec_context, parsec_context->overlay_text);
+    }
+    vdi_stream_client__context_set_connection(parsec_context, true);
+}
+
 /* Create the SDL window and initialize the renderer. If initialization fails,
  * this tears down partial video resources so the caller can try another path. */
 static bool
@@ -1292,6 +1410,13 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
         Uint64 idle_start = 0;
         bool local_interaction = false;
         bool rendered = false;
+
+        /* The decode thread aborted a decode in get_format because the stream
+         * resolution changed; rebuild the whole pipeline on a fresh device. */
+        if (vdi_stream_client__parsec_ffmpeg_resolution_reset_pending()) {
+            vdi_stream_client__resolution_reset(&parsec_context, &cfg, vdi_config);
+            continue;
+        }
 
         force_redraw = vdi_stream_client__context_input_force_redraw(&parsec_context);
         if (parsec_context.stats_enabled) {

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -681,8 +681,9 @@ vdi_stream_client__show_connection_overlay(
     *force_redraw = true;
 }
 
-/* Switch a failed HEVC connection attempt to H.264 once. This avoids repeatedly
- * mutating the client config after the fallback has already been used. */
+/* Switch a failed startup HEVC connection attempt to H.264 once. This avoids
+ * repeatedly mutating the client config after the fallback has already been
+ * used. */
 static void
 vdi_stream_client__use_h264_fallback(
     ParsecClientConfig *cfg, bool *hevc_attempt_active, bool *h264_fallback_done
@@ -753,8 +754,7 @@ vdi_stream_client__video_decoder_policy(
 static void
 vdi_stream_client__handle_connection_status(
     struct parsec_context_s *parsec_context, struct vdi_config_s *vdi_config,
-    ParsecClientConfig *cfg, Uint64 *last_time, bool *force_redraw, bool *hevc_attempt_active,
-    bool *h264_fallback_done
+    ParsecClientConfig *cfg, Uint64 *last_time, bool *force_redraw
 )
 {
     ParsecStatus e = ParsecClientGetStatus(parsec_context->parsec, &parsec_context->client_status);
@@ -767,7 +767,6 @@ vdi_stream_client__handle_connection_status(
     if (vdi_config->reconnect == 1 && e != PARSEC_CONNECTING && e != PARSEC_OK &&
         SDL_GetTicks() > *last_time + vdi_config->timeout) {
         vdi_stream_client__show_connection_overlay(parsec_context, force_redraw, "Reconnecting...");
-        vdi_stream_client__use_h264_fallback(cfg, hevc_attempt_active, h264_fallback_done);
         e = vdi_stream_client__parsec_reconnect(parsec_context, cfg, vdi_config);
         *last_time = SDL_GetTicks();
     }
@@ -1281,8 +1280,7 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
         parsec_context.render_timeout = local_interaction ? 0 : 5;
 
         vdi_stream_client__handle_connection_status(
-            &parsec_context, vdi_config, &cfg, &last_time, &force_redraw, &hevc_attempt_active,
-            &h264_fallback_done
+            &parsec_context, vdi_config, &cfg, &last_time, &force_redraw
         );
 
         for (ParsecClientEvent event; ParsecClientPollEvents(parsec_context.parsec, 0, &event);) {

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -1072,6 +1072,8 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     bool h264_acceleration = false;
     bool hevc_acceleration = false;
     bool hevc444_acceleration = false;
+    int unsupported_width = 0;
+    int unsupported_height = 0;
     bool hardware_decoding;
     Uint32 device;
     SDL_Thread *input_thread = NULL;
@@ -1245,6 +1247,16 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
         /* Wait until connection is established. */
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Connect to Parsec host\n");
         while (!parsec_context.decoder) {
+            if (vdi_stream_client__parsec_ffmpeg_unsupported_startup_size(
+                    &unsupported_width, &unsupported_height
+                )) {
+                SDL_LogError(
+                    SDL_LOG_CATEGORY_APPLICATION,
+                    "Unsupported VA-API image size %dx%d on this device; use --width and --height to override\n",
+                    unsupported_width, unsupported_height
+                );
+                goto error;
+            }
 
             /* Get client status. */
             e = ParsecClientGetStatus(parsec_context.parsec, &parsec_context.client_status);
@@ -1284,6 +1296,17 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
                         parsec_context.client_status.decoder[DEFAULT_STREAM].height;
                     parsec_context.decoder = true;
                 }
+            }
+
+            if (vdi_stream_client__parsec_ffmpeg_unsupported_startup_size(
+                    &unsupported_width, &unsupported_height
+                )) {
+                SDL_LogError(
+                    SDL_LOG_CATEGORY_APPLICATION,
+                    "Unsupported VA-API image size %dx%d on this device; use --width and --height to override\n",
+                    unsupported_width, unsupported_height
+                );
+                goto error;
             }
 
             /* Unknown error. */

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -1139,8 +1139,8 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
     /* Use client resolution if specified. */
     if (vdi_config->width > 0 && vdi_config->height > 0) {
         SDL_LogInfo(
-            SDL_LOG_CATEGORY_APPLICATION, "Override resolution %dx%d\n", vdi_config->width,
-            vdi_config->height
+            SDL_LOG_CATEGORY_APPLICATION, "Override resolution %dx%d\n", vdi_config->height,
+            vdi_config->width
         );
         cfg.video[DEFAULT_STREAM].resolutionX = vdi_config->width;
         cfg.video[DEFAULT_STREAM].resolutionY = vdi_config->height;

--- a/src/parsec.c
+++ b/src/parsec.c
@@ -1252,7 +1252,8 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
                 )) {
                 SDL_LogError(
                     SDL_LOG_CATEGORY_APPLICATION,
-                    "Unsupported VA-API image size %dx%d on this device; use --width and --height to override\n",
+                    "Unsupported VA-API image size %dx%d on this device; use --width and --height "
+                    "to override\n",
                     unsupported_width, unsupported_height
                 );
                 goto error;
@@ -1303,7 +1304,8 @@ vdi_stream_client__event_loop(struct vdi_config_s *vdi_config)
                 )) {
                 SDL_LogError(
                     SDL_LOG_CATEGORY_APPLICATION,
-                    "Unsupported VA-API image size %dx%d on this device; use --width and --height to override\n",
+                    "Unsupported VA-API image size %dx%d on this device; use --width and --height "
+                    "to override\n",
                     unsupported_width, unsupported_height
                 );
                 goto error;

--- a/src/parsec.h
+++ b/src/parsec.h
@@ -103,6 +103,7 @@ struct parsec_context_s
     SDL_Texture *texture_video;
     SDL_Texture *frame_video_texture;
     struct vdi_stream_client__placebo_s *placebo;
+    bool silent_reinit;
     bool frame_video_updated;
     SDL_PixelFormat pixel_format_video;
     Sint32 texture_width;

--- a/src/parsec.h
+++ b/src/parsec.h
@@ -85,6 +85,7 @@ struct parsec_context_s
     ParsecDSO *parsec;
 #endif
     ParsecClientStatus client_status;
+    ParsecStatus stream_error;
 
     /* video. */
     SDL_Window *window;
@@ -98,6 +99,7 @@ struct parsec_context_s
     /* sdl textures for rendering. */
     SDL_Surface *surface_ttf;
     SDL_Texture *texture_ttf;
+    char overlay_text[32];
     SDL_Texture *texture_video;
     SDL_Texture *frame_video_texture;
     struct vdi_stream_client__placebo_s *placebo;

--- a/src/placebo.c
+++ b/src/placebo.c
@@ -318,14 +318,12 @@ vdi_stream_client__placebo_memory_type(
 static bool
 vdi_stream_client__placebo_source_import_linear(
     struct vdi_stream_client__placebo_s *placebo,
-    struct vdi_stream_client__placebo_source_s *source, const AVFrame *av_frame,
+    struct vdi_stream_client__placebo_source_s *source,
     const AVDRMPlaneDescriptor *const drm_planes[2], const AVDRMObjectDescriptor *drm_object,
-    size_t object_size
+    size_t object_size, Uint32 allocation_width, Uint32 allocation_height
 )
 {
     const VkFormat vulkan_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
-    const Uint32 allocation_width = (Uint32)FFALIGN(av_frame->width, 16);
-    const Uint32 allocation_height = (Uint32)FFALIGN(av_frame->height, 16);
 
     /* RADV advertises linear external images through opaque FD handles. */
     const VkExternalMemoryHandleTypeFlagBits handle_type =
@@ -758,6 +756,11 @@ vdi_stream_client__placebo_source_map(
     }
 
     if (placebo->linear_import) {
+        int linear_width =
+            frames_context->width > av_frame->width ? frames_context->width : av_frame->width;
+        int linear_height =
+            frames_context->height > av_frame->height ? frames_context->height : av_frame->height;
+
         if (frames_context->sw_format != AV_PIX_FMT_NV12 || plane_count != 2 ||
             drm_planes[0]->object_index != drm_planes[1]->object_index ||
             drm_objects[0] != drm_objects[1] || object_sizes[0] != object_sizes[1]) {
@@ -767,8 +770,16 @@ vdi_stream_client__placebo_source_map(
             );
             goto error;
         }
+        if (linear_width <= 0 || linear_height <= 0) {
+            SDL_strlcpy(
+                placebo->import_failure, "RADV linear import has invalid allocation size",
+                sizeof(placebo->import_failure)
+            );
+            goto error;
+        }
         if (!vdi_stream_client__placebo_source_import_linear(
-                placebo, source, av_frame, drm_planes, drm_objects[0], object_sizes[0]
+                placebo, source, drm_planes, drm_objects[0], object_sizes[0],
+                (Uint32)FFALIGN(linear_width, 16), (Uint32)FFALIGN(linear_height, 16)
             )) {
             goto error;
         }
@@ -1105,8 +1116,8 @@ vdi_stream_client__placebo_init(struct parsec_context_s *parsec_context)
         }
     }
 
-    /* Only the RADV linear path shares and fragments the in-process amdgpu
-     * device, so a mid-stream resolution change needs the full pipeline reset. */
+    /* Only the RADV linear path needs the reconnect fallback when a resize cannot
+     * safely reuse the current VA-API pool. */
     vdi_stream_client__parsec_ffmpeg_enable_resolution_reset(placebo->linear_import);
     return true;
 

--- a/src/placebo.c
+++ b/src/placebo.c
@@ -1085,17 +1085,29 @@ vdi_stream_client__placebo_init(struct parsec_context_s *parsec_context)
         goto error;
     }
 
-    vkGetPhysicalDeviceProperties(placebo->vulkan->phys_device, &device_properties);
-    SDL_LogInfo(
-        SDL_LOG_CATEGORY_APPLICATION, "Use %s Vulkan device for VA-API DRM PRIME zero-copy\n",
-        device_properties.deviceName
-    );
-    if (placebo->linear_import) {
+    /* A resolution-change reset rebuilds the renderer; keep its re-initialization
+     * silent by skipping the one-time mode banners and marking the per-frame
+     * messages as already logged. */
+    if (parsec_context->silent_reinit) {
+        placebo->direct_logged = true;
+        placebo->upload_logged = true;
+    } else {
+        vkGetPhysicalDeviceProperties(placebo->vulkan->phys_device, &device_properties);
         SDL_LogInfo(
-            SDL_LOG_CATEGORY_APPLICATION,
-            "Use RADV linear external-memory import without DRM modifiers\n"
+            SDL_LOG_CATEGORY_APPLICATION, "Use %s Vulkan device for VA-API DRM PRIME zero-copy\n",
+            device_properties.deviceName
         );
+        if (placebo->linear_import) {
+            SDL_LogInfo(
+                SDL_LOG_CATEGORY_APPLICATION,
+                "Use RADV linear external-memory import without DRM modifiers\n"
+            );
+        }
     }
+
+    /* Only the RADV linear path shares and fragments the in-process amdgpu
+     * device, so a mid-stream resolution change needs the full pipeline reset. */
+    vdi_stream_client__parsec_ffmpeg_enable_resolution_reset(placebo->linear_import);
     return true;
 
 error:

--- a/src/placebo.c
+++ b/src/placebo.c
@@ -20,10 +20,13 @@
 #include "placebo.h"
 
 #include <SDL3/SDL_vulkan.h>
+#include <errno.h>
 #include <libavutil/common.h>
+#include <libavutil/error.h>
 #include <libavutil/frame.h>
 #include <libavutil/hwcontext.h>
 #include <libavutil/hwcontext_drm.h>
+#include <libavutil/hwcontext_vaapi.h>
 #include <libavutil/pixdesc.h>
 #include <libavutil/pixfmt.h>
 #include <libdrm/drm_fourcc.h>
@@ -33,7 +36,10 @@
 #include <libplacebo/utils/upload.h>
 #include <libplacebo/vulkan.h>
 #include <unistd.h>
+#include <va/va.h>
 #include <vulkan/vulkan.h>
+
+#define VDI_STREAM_CLIENT_PLACEBO_VAAPI_SYNC_RETRIES 5u
 
 struct vdi_stream_client__placebo_s
 {
@@ -221,6 +227,60 @@ vdi_stream_client__placebo_is_radv(struct vdi_stream_client__placebo_s *placebo)
     vkGetPhysicalDeviceProperties2(placebo->vulkan->phys_device, &properties);
     return properties.properties.vendorID == 0x1002 &&
            driver_properties.driverID == VK_DRIVER_ID_MESA_RADV;
+}
+
+/* Validate a VA-API frame and, on Intel iHD, pre-sync the retained surface
+ * before FFmpeg exports it as DRM PRIME. Other drivers continue through the
+ * normal FFmpeg mapping path, while transient Intel iHD sync failures are
+ * retried here before falling back to upload. */
+static bool
+vdi_stream_client__placebo_vaapi_sync(const AVFrame *av_frame)
+{
+    const AVHWFramesContext *frames_context;
+    const AVVAAPIDeviceContext *device_context;
+    const char *vendor;
+    VASurfaceID surface;
+    VAStatus status;
+
+    if (av_frame == NULL || av_frame->format != AV_PIX_FMT_VAAPI ||
+        av_frame->hw_frames_ctx == NULL) {
+        return false;
+    }
+    frames_context = (const AVHWFramesContext *)av_frame->hw_frames_ctx->data;
+    if (frames_context == NULL || frames_context->device_ctx == NULL ||
+        frames_context->device_ctx->type != AV_HWDEVICE_TYPE_VAAPI) {
+        return false;
+    }
+    device_context = (const AVVAAPIDeviceContext *)frames_context->device_ctx->hwctx;
+    if (device_context == NULL || device_context->display == NULL) {
+        return false;
+    }
+    vendor = vaQueryVendorString(device_context->display);
+    if (vendor == NULL || SDL_strstr(vendor, "Intel iHD driver") == NULL) {
+        return true;
+    }
+
+    surface = (VASurfaceID)(uintptr_t)av_frame->data[3];
+    if (surface == VA_INVALID_SURFACE) {
+        return false;
+    }
+
+    /* Intel iHD status reports can briefly lag the surface fence after a
+     * Wayland output power cycle. Retry only that specific synchronization
+     * failure before asking FFmpeg to export the same surface again. */
+    for (Uint32 attempt = 0; attempt < VDI_STREAM_CLIENT_PLACEBO_VAAPI_SYNC_RETRIES; attempt++) {
+        status = vaSyncSurface(device_context->display, surface);
+        if (status == VA_STATUS_SUCCESS) {
+            return true;
+        }
+        if (status != VA_STATUS_ERROR_OPERATION_FAILED) {
+            return false;
+        }
+        if (attempt + 1 < VDI_STREAM_CLIENT_PLACEBO_VAAPI_SYNC_RETRIES) {
+            SDL_Delay(1);
+        }
+    }
+    return false;
 }
 
 /* Pick a Vulkan memory type compatible with an imported external image,
@@ -541,7 +601,13 @@ vdi_stream_client__placebo_source_map(
         goto error;
     }
 
-    err = av_hwframe_map(source->drm_frame, av_frame, AV_HWFRAME_MAP_READ | AV_HWFRAME_MAP_DIRECT);
+    if (vdi_stream_client__placebo_vaapi_sync(av_frame)) {
+        err = av_hwframe_map(
+            source->drm_frame, av_frame, AV_HWFRAME_MAP_READ | AV_HWFRAME_MAP_DIRECT
+        );
+    } else {
+        err = AVERROR(EIO);
+    }
     if (err < 0) {
         SDL_snprintf(
             placebo->import_failure, sizeof(placebo->import_failure),

--- a/src/video.c
+++ b/src/video.c
@@ -118,6 +118,17 @@ vdi_stream_client__video_texture(
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unsupported video format: %d\n", frame->format);
         return false;
     }
+    if (parsec_context->renderer == NULL) {
+        return false;
+    }
+    if (frame->fullWidth == 0 || frame->fullHeight == 0 || frame->fullWidth > (Uint32)INT_MAX ||
+        frame->fullHeight > (Uint32)INT_MAX) {
+        SDL_LogWarn(
+            SDL_LOG_CATEGORY_APPLICATION, "Ignore invalid video frame size %ux%u\n",
+            frame->fullWidth, frame->fullHeight
+        );
+        return false;
+    }
 
     if (parsec_context->texture_video != NULL &&
         parsec_context->texture_width == (Sint32)frame->fullWidth &&

--- a/src/video.c
+++ b/src/video.c
@@ -379,11 +379,13 @@ vdi_stream_client__video_init(struct parsec_context_s *parsec_context, bool acce
         return false;
     }
 
-    renderer_name = SDL_GetRendererName(parsec_context->renderer);
-    SDL_LogInfo(
-        SDL_LOG_CATEGORY_APPLICATION, "Use %s renderer\n",
-        renderer_name != NULL ? renderer_name : "unknown"
-    );
+    if (!parsec_context->silent_reinit) {
+        renderer_name = SDL_GetRendererName(parsec_context->renderer);
+        SDL_LogInfo(
+            SDL_LOG_CATEGORY_APPLICATION, "Use %s renderer\n",
+            renderer_name != NULL ? renderer_name : "unknown"
+        );
+    }
     if (!SDL_SetRenderVSync(parsec_context->renderer, 1)) {
         SDL_LogError(
             SDL_LOG_CATEGORY_APPLICATION, "SDL_SetRenderVSync failed: %s\n", SDL_GetError()

--- a/src/video.c
+++ b/src/video.c
@@ -298,6 +298,11 @@ vdi_stream_client__frame_video(void *opaque, bool force_redraw)
             parsec_context->window_height, 1
         );
         if (e != PARSEC_OK) {
+            if (e < 0) {
+                parsec_context->stream_error = e;
+                vdi_stream_client__context_set_connection(parsec_context, false);
+                return false;
+            }
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Set dimensions failed with code: %d\n", e);
         } else {
             parsec_context->requested_width = parsec_context->window_width;
@@ -306,10 +311,15 @@ vdi_stream_client__frame_video(void *opaque, bool force_redraw)
     }
 
     parsec_context->frame_video_updated = false;
-    ParsecClientPollFrame(
+    e = ParsecClientPollFrame(
         parsec_context->parsec, DEFAULT_STREAM, vdi_stream_client__frame_video_update,
         parsec_context->render_timeout, parsec_context
     );
+    if (e < 0) {
+        parsec_context->stream_error = e;
+        vdi_stream_client__context_set_connection(parsec_context, false);
+        return false;
+    }
 
     if (!force_redraw && !parsec_context->frame_video_updated) {
         return false;


### PR DESCRIPTION
## Summary

* Bump the project version to 0.5.1 for the next release.
* Recover VA-API zero-copy rendering after display power transitions by pre-synchronizing Intel iHD surfaces and retrying transient operation failures before DRM PRIME export.
* Preserve the requested codec and color mode across runtime reconnects instead of applying the HEVC-to-H.264 startup fallback after the initial connection.
* Treat negative Parsec video API returns as stream failures and route them through the normal reconnect flow with the existing reconnect overlay.
* Reuse the FFmpeg VA-API decoder across reconnects so pre-GFX9 AMD/RADV systems avoid recreating a failing VA-API/UVD context on an aged shared amdgpu device.
* Recover VA-API zero-copy rendering on mid-stream resolution changes by rebuilding the RADV renderer and decoder on a fresh device when required.
* Reuse a manual RADV VA-API frame pool for in-stream downscales while keeping the full reset path for unsafe upscales or failed reconfiguration.
* Reject unsupported RADV VA-API resize targets before frame-pool setup and keep the last working resolution instead of reconnecting into an invalid target.
* Harden video texture handling during resets by ignoring late frames when the SDL renderer is unavailable and rejecting invalid frame sizes.
* Fail fast on unsupported VA-API startup sizes and report that users can override the resolution with `--width` and `--height`.
* Restore the expected override resolution log order and clean up RADV resize logging.
* Fix clang-format lint violations introduced by the VA-API resize handling changes.

## Commit Overview

* 71eb453 - chore(release): bump version
* 773290b - fix(video): recover VA-API rendering after display power transitions
* d1118ad - fix(parsec): preserve requested codec on reconnect
* 48b62aa - fix(parsec): show reconnect overlay on stream failure
* 21667d4 - fix(ffmpeg): reuse VA-API decoder across reconnect
* 9a5769c - fix(parsec): recover VA-API zero-copy on mid-stream resolution change
* 4f1396e - fix(ffmpeg): reuse RADV VA-API frame pool for downscales
* 558156f - fix(ffmpeg): reject unsupported vaapi resize targets on RADV
* ebc2107 - fix(video): harden video_texture during reset
* e7bebb8 - chore(logging): simplify RADV vaapi resize notifications
* 58bea63 - fix(ffmpeg): fail fast on unsupported vaapi startup sizes
* ff7892c - fix(parsec): restore override resolution log order after f6af7a7
* 4a54516 - style: fix clang-format lint violations